### PR TITLE
Update CoExtendedAttributesController.php

### DIFF
--- a/app/Controller/CoExtendedAttributesController.php
+++ b/app/Controller/CoExtendedAttributesController.php
@@ -242,8 +242,8 @@ class CoExtendedAttributesController extends StandardController {
         $sql = "CREATE TABLE " . $cotable . " (
                 id SERIAL PRIMARY KEY,
                 co_person_role_id INTEGER REFERENCES " . $this->CoExtendedAttribute->tablePrefix . "co_person_roles(id),
-                created TIMESTAMP,
-                modified TIMESTAMP
+                created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                modified TIMESTAMP DEFAULT CURRENT_TIMESTAMP
               );";
         
         if($this->CoExtendedAttribute->query($sql) === false) {


### PR DESCRIPTION
The TIMESTAMP column does not work without DEFAULT in some recent versions of mysql. This causes a nasty, unexplained DB error in COmanage when attempting to create extended attributes.