### PR TITLE
CO-1362 Submit form once

### DIFF
--- a/app/View/OrgIdentities/search.inc
+++ b/app/View/OrgIdentities/search.inc
@@ -105,7 +105,6 @@ $tabIndex = 1;
       'empty'   => _txt('op.select.empty-a', array(_txt('ct.org_identity_sources.1'))),
       'label'   => _txt('ct.org_identity_sources.1'),
       'tabindex' => $tabIndex++,
-      'onchange' => 'this.form.submit()',
       'value'   => (!empty($this->request->params['named']['Search.orgIdentitySource'])
                     ? $this->request->params['named']['Search.orgIdentitySource']
                     : ''));


### PR DESCRIPTION
Selecting an Organizational Identity Source automatically submits the form so that clicking submit would therefore submit twice and likely break CakePHP's csrf checks.