### PR TITLE
Fixes error 500 on GrouperProvisioning

### DIFF
--- a/app/Plugin/GrouperProvisioner/Model/CoGrouperProvisionerGroup.php
+++ b/app/Plugin/GrouperProvisioner/Model/CoGrouperProvisionerGroup.php
@@ -313,6 +313,10 @@ class CoGrouperProvisionerGroup extends AppModel {
   }
 
   public function updateProvisionerGroup($provisionerGroup) {
+    if (empty($provisionerGroup)) {
+      return;
+    }
+    
     if(isset($provisionerGroup['CoGrouperProvisionerGroup']['modified'])) {
       unset($provisionerGroup['CoGrouperProvisionerGroup']['modified']);
     }


### PR DESCRIPTION
Error 500 occurs when no provisioninggroups is empty

@boshrin &  @skoranda This fix applies to both hotfix-2.0.x and hotfix-3.0.x