### PR TITLE
CO-1605: implementation of a text body field for Terms&Conditions to …

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -2064,6 +2064,7 @@
     </field>
     <field name="description" type="C" size="256" />
     <field name="url" type="C" size="256" />
+    <field name="tc_body" type="X2" />
     <field name="cou_id" type="I">
       <constraint>REFERENCES cm_cous(id)</constraint>
     </field>

--- a/app/Controller/CoTermsAndConditionsController.php
+++ b/app/Controller/CoTermsAndConditionsController.php
@@ -195,10 +195,35 @@ class CoTermsAndConditionsController extends StandardController {
     // Modify ordering for display via AJAX
     $p['reorder'] = ($roles['cmadmin'] || $roles['coadmin']);
 
+    // A raw view of the T&C content is always allowed
+    $p['raw_view']=TRUE;
+
     $this->set('permissions', $p);
     return $p[$this->action];
   }
-  
+
+  /**
+   * Raw view of the T&C
+   * Necessary for CO-1605, to enable viewing of T&C through the existing
+   * framework, as well as storing the relevant T&C as URL in the LDAP
+   * provisioner.
+   *
+   * @since  COmanage Registry v3.2.0
+   * @param  Integer $id CO Terms and Agreements identifier
+   * @return void
+   */
+
+  public function raw_view($id) {
+    $args = array();
+    $args['conditions'][$this->modelClass.'.id'] = $id;
+
+    $tc = $this->CoTermsAndConditions->find('first', $args);
+
+    print ($tc[$this->modelClass]['tc_body']);
+
+    exit(0);
+  }
+
   /**
    * Pull T&C for review
    * - precondition: The named parameter 'copersonid' is populated with the target CO Person ID

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1476,6 +1476,8 @@ original notification at
   'fd.tc.agree.no' => 'Not Agreed',
   'fd.tc.agree.yes' => 'Agreed',
   'fd.tc.archived' => 'The definition of this T&C changed after the agreement was recorded',
+  'fd.tc.body' => 'Content',
+  'fd.tc.body.desc' => 'HTML content of these T&C',
   'fd.tc.cou.desc' => 'If set, this T&C only applies to members of the specified COU',
   'fd.tc.for' =>      'Terms and Conditions for %1$s (%2$s)',
   'fd.tc.mode.login' => 'Terms and Conditions Mode',

--- a/app/Model/CoTermsAndConditions.php
+++ b/app/Model/CoTermsAndConditions.php
@@ -50,10 +50,16 @@ class CoTermsAndConditions extends AppModel {
       'allowEmpty' => false
     ),
     'url' => array(
-      'rule' => array('url', true),
-      'required' => true,
-      'allowEmpty' => false,
-      'message' => 'A URL must be provided'
+      'rule' => array("checkUrlOrContent"),
+      'required' => false,
+      'type' => 'textarea',
+      'message' => "" // empty message causes field to get error state without duplicate message
+    ),
+    'tc_body' => array(
+      'rule' => array("checkUrlOrContent"),
+      'required' => false,
+      'type' => 'textarea',
+      'message' => "Either URL or Content must be set for this T&C"
     ),
     'cou_id' => array(
       'rule' => 'numeric',
@@ -203,5 +209,25 @@ class CoTermsAndConditions extends AppModel {
     }
 
     return true;
+  }
+
+  /**
+   * Validation callback
+   * Check that either URL or Content is not-blank
+   *
+   * @since  COmanage Registry v3.2.0
+   * @param  CakeValidationSet  field
+   * @param  String             new data for this field
+   * @param  Model              model object
+   * @return Boolean validation state
+   */
+
+  public function checkUrlOrContent($field, $rule) {
+    CakeLog::write('debug','received field '.json_encode($field));
+    $url = $this->data[$this->alias]['url'];
+    $body = $this->data[$this->alias]['tc_body'];
+    $status = !(empty($url) && empty($body));
+    CakeLog::write('debug','status is '.($status ? "TRUE":"FALSE"));
+    return $status;
   }
 }

--- a/app/Plugin/LdapProvisioner/Model/CoLdapProvisionerTarget.php
+++ b/app/Plugin/LdapProvisioner/Model/CoLdapProvisionerTarget.php
@@ -600,16 +600,26 @@ class CoLdapProvisionerTarget extends CoProvisionerPluginTarget {
                 if(!$attropts) {
                   $attributes[$attr] = array();
                 }
-                
+
                 foreach($provisioningData['CoTAndCAgreement'] as $tc) {
                   if(!empty($tc['agreement_time'])
-                     && !empty($tc['CoTermsAndConditions']['url']
-                     && $tc['CoTermsAndConditions']['status'] == SuspendableStatusEnum::Active)) {
+                     && !(empty($tc['CoTermsAndConditions']['url'])
+                          && empty($tc['CoTermsAndConditions']['tc_body']))
+                     && $tc['CoTermsAndConditions']['status'] == SuspendableStatusEnum::Active) {
+
+                    $url = empty($tc['CoTermsAndConditions']['tc_body'])
+                           ? $tc['CoTermsAndConditions']['url']
+                           : Router::url(array(
+                             "controller" => "CoTermsAndConditions",
+                             "action" => "raw_view",
+                             $tc['CoTermsAndConditions']['id']
+                           ), true);
+
                     if($attropts) {
                       $lrattr = $lattr . ";time-" . strtotime($tc['agreement_time']);
-                      $attributes[$lrattr][] = $tc['CoTermsAndConditions']['url'];
+                      $attributes[$lrattr][] = $url;
                     } else {
-                      $attributes[$attr][] = $tc['CoTermsAndConditions']['url'];
+                      $attributes[$attr][] = $url;
                     }
                   }
                 }

--- a/app/View/CoPetitions/petition-attributes.inc
+++ b/app/View/CoPetitions/petition-attributes.inc
@@ -532,12 +532,19 @@
       </div>
       <ul id="co_petition_tandc">
         <?php foreach($vv_terms_and_conditions as $t): ?>
+          <?php $url = empty($t['CoTermsAndConditions']['tc_body']) 
+                  ? $t['CoTermsAndConditions']['url'] 
+                  : Router::url(array(
+                    "controller" => "CoTermsAndConditions",
+                    "action" => "raw_view",
+                    $t['CoTermsAndConditions']['id']
+                  )); ?>
           <li class="line<?php print ($l % 2); $l++; ?>">
               <strong><?php print filter_var($t['CoTermsAndConditions']['description'],FILTER_SANITIZE_SPECIAL_CHARS); ?></strong><br/>
               <button class="checkbutton"
                       type="button"
                       onClick="open_tandc('<?php print addslashes($t['CoTermsAndConditions']['description']); ?>',
-                        '<?php print addslashes($t['CoTermsAndConditions']['url']); ?>',
+                        '<?php print addslashes($url); ?>',
                         '<?php print addslashes($t['CoTermsAndConditions']['id']); ?>')">
                 <?php print _txt('op.tc.review'); ?>
               </button>

--- a/app/View/CoTermsAndConditions/fields.inc
+++ b/app/View/CoTermsAndConditions/fields.inc
@@ -96,14 +96,26 @@
       <div class="field-name">
         <div class="field-title">
           <?php print ($e ? $this->Form->label('url', _txt('fd.url')) : _txt('fd.url')); ?>
-          <span class="required">*</span>
         </div>
         <div class="field-desc"><?php print _txt('fd.tc.url.desc'); ?></div>
       </div>
       <div class="field-info">
         <?php print ($e
-                     ? $this->Form->input('url', array('size' => '60'))
+                     ? $this->Form->input('url', array('size' => '60', 'required'=>FALSE))
                      : filter_var($co_terms_and_conditions[0]['CoTermsAndConditions']['url'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
+      </div>
+    </li>
+    <li class="field-stack">
+      <div class="field-name">
+        <div class="field-title">
+          <?php print ($e ? $this->Form->label('tc_body', _txt('fd.tc.body')) : _txt('fd.tc.body')); ?>
+        </div>
+        <span class="descr"><?php print _txt('fd.tc.body.desc'); ?></span>
+      </div>
+      <div class="field-info">
+        <?php print ($e
+                     ? $this->Form->input('tc_body', array('required'=>FALSE))
+                     : filter_var($co_terms_and_conditions[0]['CoTermsAndConditions']['tc_body'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
       </div>
     </li>
     <li>

--- a/app/View/CoTermsAndConditions/review.ctp
+++ b/app/View/CoTermsAndConditions/review.ctp
@@ -136,11 +136,18 @@
           ?>
         </td>
         <td>
+          <?php $url = empty($c['CoTermsAndConditions']['tc_body']) 
+                  ? $c['CoTermsAndConditions']['url'] 
+                  : Router::url(array(
+                    "controller" => "CoTermsAndConditions",
+                    "action" => "raw_view",
+                    $c['CoTermsAndConditions']['id']
+                  )); ?>
           <?php if(!empty($c['CoTAndCAgreement'])): ?>
           <button class="checkbutton"
                   type="button"
                   onClick="open_tandc('<?php print addslashes($c['CoTermsAndConditions']['description']); ?>',
-                                      '<?php print addslashes($c['CoTermsAndConditions']['url']); ?>',
+                                      '<?php print addslashes($url); ?>',
                                       'review',
                                       '')">
             <?php print _txt('op.tc.review'); ?>
@@ -149,7 +156,7 @@
           <button class="checkbutton"
                   type="button"
                   onClick="open_tandc('<?php print addslashes($c['CoTermsAndConditions']['description']); ?>',
-                                      '<?php print addslashes($c['CoTermsAndConditions']['url']); ?>',
+                                      '<?php print addslashes($url); ?>',
                                       'agree',
                                       '<?php
                                           $args = array(


### PR DESCRIPTION
This PR implements a fix for CO-1605: adding a body field to the T&C to override the URL setting. It implements a local URL that displays the T&C content in raw form. 
There is only a sanity filter on the T&C body and no filter on its output. I assume there are possibilities for administrators with bad intentions to display vulnerable javascript exploits in this way, but I am not sure if that is an issue. Alternatively, the raw view could strip tags to only allow some well-known markup tags (p, hN, em, i, b, div, span,body,html,img(?),a, etc.)

Additionally, support could be added to display non-HTML content by wrapping it in html tags and applying nl2br()

More additionally, HTML content could be stripped and only text content supported, but that would reduce the layout possibilities. That could be countered by supporting a form of markdown, but that might go too far at this point.

This PR also fixes a syntax issue in the LdapProvisioner around the original empty() check on the URL. A bracket was missing after the empty().

I tested LdapProvisioning of a voPerson objectclass. I tested checking the T&C at login. I tried testing the T&C during enrollment, but encountered the issue that for invitation flows, the administrator initiating the flow needs to agree to the T&C. I think accepting the T&C during enrollment should be moved to the phase where you accept your enrollment attributes. That would circumvent this specific issue and it could be argued that you don't need to accept the T&C to start the enrollment, but only to finish (or 'definitely accept') it.