### PR TITLE
When using OIS in the collectIdentifier phase, the enrollment should …

### DIFF
--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -985,7 +985,8 @@ class CoPetitionsController extends StandardController {
         $enrolleeToken = $this->CoPetition->field('enrollee_token', array('CoPetition.id' => $id));
         $petitionerToken = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $id));
 
-        if($action == "collectIdentifierIdentify") {
+        $steps = $this->CoPetition->CoEnrollmentFlow->configuredSteps($this->enrollmentFlowID());
+        if(isset($steps[$action]) && $steps[$action]['role'] == EnrollmentRole::Enrollee) {
           $token = empty($enrolleeToken) ? $petitionerToken : $enrolleeToken;
         }
         else {

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -982,16 +982,18 @@ class CoPetitionsController extends StandardController {
         );
         
         // If we're in an unauthenticated flow, we need to append a token.
-        $token = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $id));
-        
+        $enrolleeToken = $this->CoPetition->field('enrollee_token', array('CoPetition.id' => $id));
+        $petitionerToken = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $id));
+
+        if($action == "collectIdentifierIdentify") {
+          $token = empty($enrolleeToken) ? $petitionerToken : $enrolleeToken;
+        }
+        else {
+          $token = empty($petitionerToken) ? $enrolleeToken : $petitionerToken;
+        }
+
         if($token) {
           $redirect['token'] = $token;
-        } else {
-          $token = $this->CoPetition->field('enrollee_token', array('CoPetition.id' => $id));
-          
-          if($token) {
-            $redirect['token'] = $token;
-          }
         }
 
         $this->redirect($redirect);

--- a/app/Model/CoEnrollmentFlow.php
+++ b/app/Model/CoEnrollmentFlow.php
@@ -652,6 +652,10 @@ class CoEnrollmentFlow extends AppModel {
       // that a notification will also go out
       $ret['provision']['label'] = _txt('ef.step.provision.notify');
     }
+
+    // Set values for the OIS related sub-steps
+    $ret['selectOrgIdentityAuthenticate'] = $ret['selectOrgIdentity'];
+    $ret['collectIdentifierIdentify'] = $ret['collectIdentifier'];
     
     return $ret;
   }

--- a/app/Plugin/EnvSource/Controller/EnvSourceCoPetitionsController.php
+++ b/app/Plugin/EnvSource/Controller/EnvSourceCoPetitionsController.php
@@ -51,11 +51,12 @@ class EnvSourceCoPetitionsController extends CoPetitionsController {
     $noAuth = false;
     
     // For self signup, we simply require a token (and for the token to match).
-    $token = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $this->parseCoPetitionId()));
+    $petitionerToken = $this->CoPetition->field('petitioner_token', array('CoPetition.id' => $this->parseCoPetitionId()));
+    $enrolleeToken = $this->CoPetition->field('enrollee_token', array('CoPetition.id' => $this->parseCoPetitionId()));
     $passedToken = $this->parseToken();
-    
-    if($token && $token != '' && $passedToken) {
-      if($token == $passedToken) {
+
+    if(!(empty($petitionerToken) && empty($enrolleeToken)) && !empty($passedToken)) {
+      if($enrolleeToken == $passedToken || $petitionerToken == $passedToken) {
         // If we were passed a reauth flag, we require authentication even though
         // the token matched. This enables account linking.
         if(!isset($this->request->params['named']['reauth'])


### PR DESCRIPTION
This fix checks the phase of the enrollment to see if it needs to pass a petitioner-token (in case of selectOrgIdentityAuthenticate) or a enrollee-token (in case of collectIdentifierIdentify). 

It also fixes EnvSource to allow an enrollee token in the beforeFilter method, which would otherwise throw an 'invalid token' exception. Apparently the isAuthorized method was already fixed to check on enrollee-token. In the 3.1.0 release, it would check on petitioner-token instead, but I cannot seem to find the commit and/or documentation that indicated that change.