### PR TITLE
syncOIS: Added loop-continue to prevent unknown-variable errors (NOJIRA)

### DIFF
--- a/app/Model/OrgIdentitySource.php
+++ b/app/Model/OrgIdentitySource.php
@@ -1461,6 +1461,7 @@ class OrgIdentitySource extends AppModel {
                                                      null,
                                                      null,
                                                      JobStatusEnum::Failed);
+        continue;
       }
       
       $this->Co->CoJob->CoJobHistoryRecord->record($jobId,


### PR DESCRIPTION
When configuring an OIS like ORCID or EnvSource for 'Full' synchronisation, the code reaches a point (line 1469) where the sourceKeys and knownKeys variables are used in error message output. These variables are not defined at that scope due to a domain-exception of the OIS.

This fix adds a continue after registering the job-fail-history record. As the 'newKeys' variable is empty in this case, the following code would not be executed as well.

Alternatives are to create empty sourceKeys and knownKeys or to put the history record generation inside the try-catch above.