### PR TITLE
Implementation to get defaults from associated OIS records upon start…

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -1425,6 +1425,7 @@
     <field name="affiliation" type="C" size="32" />
     <field name="value" type="C" size="80" />
     <field name="modifiable" type="L" />
+    <field name="org_identity" type="L" />
     <field name="created" type="T" />
     <field name="modified" type="T" />
     <field name="co_enrollment_attribute_default_id" type="I">

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -469,11 +469,11 @@ class CoPetitionsController extends StandardController {
               }
             }
           }
-          
+
           $enrollmentAttributes = $this->CoPetition
                                        ->CoEnrollmentFlow
                                        ->CoEnrollmentAttribute
-                                       ->mapEnvAttributes($enrollmentAttributes, array());
+                                       ->mapEnvAttributes($enrollmentAttributes, array(), $this->parseCoPetitionId());
         }
         
         $this->set('co_enrollment_attributes', $enrollmentAttributes);

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1134,6 +1134,8 @@ original notification at
   'fd.ed.default' =>  'Default Value',
   'fd.ed.modify'  =>  'Modifiable',
   'fd.ed.modify.desc' => 'If false, the Petitioner cannot change the default value placed into the Petition',
+  'fd.ed.default_oi' => 'Take default from OrgIdentitySource',
+  'fd.ed.default_oi.desc' => 'If checked, try to find a default value on any attached OrgIdentitySource record for this petitioner if no default was found through environment values.',
   'fd.ef.aea' =>      'Require Authentication For Administrator Enrollment',
   'fd.ef.aea.desc' => 'If administrator enrollment is enabled, require enrollees to authenticate to the platform in order to complete their enrollment',
   'fd.ef.aee' =>      'Require Email Confirmation For Administrator Enrollment',

--- a/app/View/CoEnrollmentAttributes/fields.inc
+++ b/app/View/CoEnrollmentAttributes/fields.inc
@@ -647,6 +647,19 @@
               ? _txt('fd.yes') : _txt('fd.no'))); ?>
         </td>
       </tr>
+      <tr class="line<?php print ($l % 2); $l++; ?>">
+        <td>
+          <b><?php print _txt('fd.ed.default_oi'); ?></b><br />
+          <span class="descr"><?php print _txt('fd.ed.default_oi.desc'); ?></span>
+        </td>
+        <td>
+          <?php print ($e
+            ? $this->Form->input('CoEnrollmentAttributeDefault.0.org_identity',
+              array('default' => true))
+            : ($co_enrollment_attributes[0]['CoEnrollmentAttributeDefault'][0]['org_identity']
+              ? _txt('fd.yes') : _txt('fd.no'))); ?>
+        </td>
+      </tr>
     </tbody>
     <tfoot>
       <tr>


### PR DESCRIPTION
Basic implementation which retrieves the 'associated' values of linked OIS records of a petition when filling default values for relevant data elements.
This does not do much by itself as long as fields like Name and Email cannot have a default setting (as covered in CO-1628)