### PR TITLE
Checking associated email addresses during enrollment to propagate verification status

### DIFF
--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -1594,7 +1594,10 @@ class CoPetition extends AppModel {
     
     // Set for future saveFields
     $this->id = $id;
-    
+
+    // create a cache of OIds for later use
+    $ois=array();
+
     // Obtain a list of attributes that are to be copied to the CO Person (Role) from the Org Identity
     
     $cArgs = array();
@@ -2007,7 +2010,10 @@ class CoPetition extends AppModel {
         } else {
           $dbc->rollback();
           throw new RuntimeException(_txt('er.db.save-a', array('CoOrgIdentityLink')));
-        }        
+        }
+
+        // cache the OrgIdentity ID for email matching later on
+        $ois[]=$porgid;
       }
     }
     
@@ -2038,6 +2044,15 @@ class CoPetition extends AppModel {
     // Commit
     $dbc->commit();
     
+    // Check to see if there are any email addresses set to both unverified and verified for the same
+    // set of OIs and CoPersonId. If a user enters the same address as verified through a trusted OIS,
+    // that address can be considered verified without testing
+    if(!empty($orgIdentityId)) {
+      // should never be empty at this stage
+      $ois[]=$orgIdentityId;
+    }
+    $this->EnrolleeCoPerson->EmailAddress->testVerifiedAddresses($ois,$coPersonId);
+
     return true;
   }
   


### PR DESCRIPTION
This PR checks all email addresses associated with the OrgIdentities and CoPerson record after receiving 'petitionerAttributes'. Any email addresses that match an already verified address (possibly due to the email address coming from a verified OIS) are set to verified as well. 

The use case is for users that are asked to enter an optional preferred email address that is copied to their CoPerson information. Chances are this email address matches the one supplied by their IdP and so can be considered verified immediately.