### PR TITLE
Creating array for contains specification

### DIFF
--- a/app/Model/CoPetition.php
+++ b/app/Model/CoPetition.php
@@ -2058,8 +2058,8 @@ class CoPetition extends AppModel {
     
     $args = array();
     $args['conditions']['CoPetition.id'] = $id;
-    $args['contain']['CoEnrollmentFlow'] = 'CoEnrollmentFlowApprovalMessageTemplate';
-    $args['contain']['CoEnrollmentFlow'] = 'CoEnrollmentFlowFinMessageTemplate';
+    $args['contain']['CoEnrollmentFlow'][] = 'CoEnrollmentFlowApprovalMessageTemplate';
+    $args['contain']['CoEnrollmentFlow'][] = 'CoEnrollmentFlowFinMessageTemplate';
     $args['contain']['EnrolleeCoPerson'] = array('PrimaryName', 'Identifier');
     $args['contain']['EnrolleeCoPerson']['CoPersonRole'][] = 'Cou';
     $args['contain']['EnrolleeCoPerson']['CoPersonRole']['SponsorCoPerson'][] = 'PrimaryName';


### PR DESCRIPTION
Contains argument for FinMessageTemplate overwrites that for ApprovalMessageTemplate, causing the latter to not be included and hence never used.