### PR TITLE
Select list petition attribute fix for empty and required settings

### DIFF
--- a/app/View/CoPetitions/petition-attributes.inc
+++ b/app/View/CoPetitions/petition-attributes.inc
@@ -211,7 +211,9 @@
 
           // Is the MVPA required? We'll just check the first attribute since they
           // should all be the same.
-          if($mvpa && $coe_attributes[0]['mvpa_required'] && $this->action != 'view') {
+          if( (($mvpa && $coe_attributes[0]['mvpa_required']) 
+              || (!$mvpa && $coe_attributes[0]['required']))
+             && $this->action != 'view') {
             print "<span class=\"required\">*</span>\n";
           }
           
@@ -294,7 +296,20 @@
                 $args['value'] = $ea['default'];
                 $args['disabled'] = !$ea['modifiable'];
               }
-              $args['empty'] = !$ea['required'];
+
+              // An attribute is required if (1) it is part of an MVPA that is required
+              // and the field itself is required, or (2) it is not part of an MVPA and
+              // the field itself is required
+              $args['required'] = false;
+              if(isset($ea['mvpa_required']) && $ea['mvpa_required']) {
+                  $args['required'] = $ea['required'];
+              } else {
+                $args['required'] = $ea['required'];
+              }
+
+              // Always show an empty field, even if required
+              // This forces users to choose (CO-1655)
+              $args['empty'] = '';
               $args['class'] = 'co-selectfield';
               $args['aria-label'] = $m;
 


### PR DESCRIPTION
The use case is: enrollment flows that have 'Affiliation' as attribute (explicitely) without a default generate a Select element without an empty option, causing the first option to be a default anyway.

This PR implements a fix in the following way:
- the 'empty' option for Select elements was not set for 'required' attributes (supposedly to prevent people from selecting the empty value even if it was not valid). This was removed: an empty value is now always generated
- the validation step for petition attributes was fixed. Previously, if no valid affiliation was selected, the CoPersonRole validation would fail, but no exception was thrown, so the whole process would continue anyway. This affects other validations as well. 
- finally, even though Affiliation is a required element (even if set to 'optional'), no 'required' asterix was printed. This was fixed in the petition attributes view.