### PR TITLE
Fix for CO1665

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -485,6 +485,7 @@
     <field name="sync_on_update" type="L" />
     <field name="sync_on_delete" type="L" />
     <field name="create_role" type="L" />
+    <field name="link_name" type="L" />
     <field name="sync_cou_id" type="I">
       <constraint>REFERENCES cm_cous(id)</constraint>
     </field>

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1421,6 +1421,7 @@ original notification at
   'fd.pi.sync.role' => 'Create CO Person Role Record',
   'fd.pi.sync.str' => 'Sync Strategy',
   'fd.pi.sync.upd' => 'Sync on Update',
+  'fd.pi.sync.link' => 'Link Name',
   'fd.pipeline' =>    'Pipeline',
   'fd.pipeline.desc.ef' => 'Org Identities created directly (not via an Org Identity Source) from this Enrollment Flow will be processed using the specified Pipeline',
   'fd.pipeline.desc.ois' => 'Org Identities created from this Source will be processed using the specified Pipeline',

--- a/app/Model/CoPipeline.php
+++ b/app/Model/CoPipeline.php
@@ -110,6 +110,11 @@ class CoPipeline extends AppModel {
       'required'   => false,
       'allowEmpty' => true
     ),
+    'link_name' => array(
+      'rule'       => 'boolean',
+      'required'   => false,
+      'allowEmpty' => true
+    ),
     'create_role' => array(
       'rule'       => 'boolean',
       'required'   => false,
@@ -539,11 +544,15 @@ class CoPipeline extends AppModel {
         throw new RuntimeException(_txt('er.db.save-a', array('CoOrgIdentityLink')));
       }
       
-      // And create a Primary Name. We use the source's Primary Name here, but
-      // we don't actually link it to the source. This is in case the source record
-      // goes away and we want to ensure we still have a name record attached to the
-      // CO Person. (Under most circumstances the OIS name will be preserved, but eg
+      // And create a Primary Name. We use the source's Primary Name here.
+      // If 'link_name' is false, we do not actually link the name to the source.
+      // This is meant to cover cases where the source record goes away and we
+      // want to ensure we still have a name record attached to the CO Person.
+      // (Under most circumstances the OIS name will be preserved, but eg
       // an admin might try to clear out all associated data.)
+      //
+      // However, this also prevents updates of the name if the record does
+      // change on the OrgIdentity side (name corrections, marital status, etc.)
       
       $name = array(
         'Name' => array(
@@ -555,7 +564,7 @@ class CoPipeline extends AppModel {
           'suffix'         => $orgIdentity['PrimaryName']['suffix'],
           'type'           => $orgIdentity['PrimaryName']['type'],
           'primary_name'   => true,
-//          'source_name_id' => $orgIdentity['PrimaryName']['id'],
+          'source_name_id' => $coPipeline['CoPipeline']['link_name'] ? $orgIdentity['PrimaryName']['id'] : null,
         )
       );
       

--- a/app/View/CoPipelines/fields.inc
+++ b/app/View/CoPipelines/fields.inc
@@ -328,6 +328,17 @@
           </li>
           <li>
             <div class="field-name">
+              <div class="field-title"><?php print _txt('fd.pi.sync.link'); ?></div>
+            </div>
+            <div class="field-info checkbox">
+              <?php print ($e
+                           ? $this->Form->input('link_name') . ' ' .
+                             $this->Form->label('link_name', _txt('fd.pi.sync.link'))
+                           : (isset($co_pipelines[0]['CoPipeline']['link_name']) ? _txt('fd.yes') : _txt('fd.no'))); ?>
+            </div>
+          </li>
+          <li>
+            <div class="field-name">
               <div class="field-title"><?php print _txt('fd.pi.sync.role'); ?></div>
             </div>
             <div class="field-info checkbox">


### PR DESCRIPTION
We link the Pipeline created CoPerson and CoPersonRole to the petition after OrgIdentity creation by attached OIS plugins. 

This also introduces a 'link name' setting for Pipelines that allow linking the primary name specifically (which is otherwise explicitely not linked)