### PR TITLE
Fix to allow plugins to execute optional Enrollment steps

### DIFF
--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -741,6 +741,10 @@ class CoPetitionsController extends StandardController {
             $redirect['token'] = $token;
           }
           
+          if($step == "start" && !empty($this->request->params['named']['return'])) {
+            $redirect['return'] = $this->request->params['named']['return'];
+          }
+
           $this->redirect($redirect);
           break;
         }
@@ -756,6 +760,10 @@ class CoPetitionsController extends StandardController {
         
         // Generate hint URL for where to go when the step is completed
         $onFinish = $this->generateDoneRedirect($step, $id, $curPlugin);
+        if($step == "start" && !empty($this->request->params['named']['return'])) {
+          $onFinish['return'] = $this->request->params['named']['return'];
+        }
+
         $this->set('vv_on_finish_url', $onFinish);
         
         // Run the step

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -816,6 +816,9 @@ class CoPetitionsController extends StandardController {
           
           // Make sure we don't issue a redirect
           return;
+        } else {
+          // Not in a plugin and this step is optional. Redirect to the plugin phase 
+          $this->redirect($onFinish);
         }
       }
     }


### PR DESCRIPTION
This adds an else-block at the end of the tests for the current step. The first test looks to see if this is a 'curPlugin', the next test looks for RequiredEnum::Required steps. This leaves out the phase where we are not in a 'curPlugin' and the step is RequiredEnum::Optional (which would be the initial case for any optional step).

The effect of this can be easily tested: create an execute_plugin_start step in any enrollment plugin and have it output some debug text (or redirect to a view). This code is only executed if the enrollment requires the start phase (ie: if it has some introduction text configured). Without the introduction-text, the start phase is effectively skipped.