### PR TITLE
Quick fix for CO1667

### DIFF
--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -781,7 +781,7 @@ class CoPetitionsController extends StandardController {
             // Log the error into the petition history
             $this->CoPetition
                  ->CoPetitionHistoryRecord
-                 ->record($coPetitionId,
+                 ->record($id,
                           $this->Session->read('Auth.User.co_person_id'),
                           PetitionActionEnum::StepFailed,
                           $e->getMessage());
@@ -862,8 +862,7 @@ class CoPetitionsController extends StandardController {
           // Because the URL is in a parameter, we expect it to be encoded.
           // We use base64 to avoid weird parsing errors with partially
           // visible URLs in a URL.
-          
-          $returnUrl = base64_decode($this->request->params['named']['return']);
+          $returnUrl = base64_decode(str_replace("-","/",$this->request->params['named']['return']));
         }
         
         $ptid = $this->CoPetition->initialize($efId,


### PR DESCRIPTION
Dashes in the base64 encoded parameter are replaced by slashes (which would be interpreted as path separators). This is merely a suggestion, but as a workaround was required for us locally, we are going to apply this in the Surfnet fork.

Against all etiquette, this concept PR also includes a parameter change for history notifications in case of plugin exceptions. This ought to have been a separate PR.