### PR TITLE
Easy fix for CO-1668

### DIFF
--- a/app/Controller/Component/RoleComponent.php
+++ b/app/Controller/Component/RoleComponent.php
@@ -444,7 +444,9 @@ class RoleComponent extends Component {
     $controller = $this->_Collection->getController();
     
     $coId = $controller->cur_co['Co']['id'];
-    
+    if(empty($coId)) {
+      $coId = $controller->parseCOID();
+    }
     // Figure out the revelant CO Person ID for the current user and the current CO
     
     $CoPerson = ClassRegistry::init('CoPerson');


### PR DESCRIPTION
When CoPetitionsController calls isAuthorize in the beforeFilter method, the cur_co object is not yet set (which is done by the parent::beforeFilter call). 
To retrieve a missing CO-id in the RoleComponent::calculateCMRoles method, this fix calls the AppController::parseCOID method, which returns a valid CO-id if one can be found. This same call is used as basis to populate the cur_co object in AppController::beforeFilter, but it avoids having to retrieve the whole object.

Worst case scenario would be publicly accessible pages, where parseCOID would be called twice, because an empty variable is returned. 