### PR TITLE
Fix for CO-1703: wrong URL parameter passed for Services portal

### DIFF
--- a/app/View/Elements/menuMain.ctp
+++ b/app/View/Elements/menuMain.ctp
@@ -315,7 +315,7 @@ $efcos = Hash::extract($vv_enrollment_flow_cos, '{n}.CoEnrollmentFlow.co_id');
           $args['controller'] = 'co_services';
           $args['action'] = 'portal';
           if($sCouId > -1) {
-            $args['couid'] = $sCouId;
+            $args['cou'] = $sCouId;
           } else {
             $args['co'] = $menuCoId;
           }


### PR DESCRIPTION
the CoServices::parseCOID expects a 'cou' parameter and this is generated elsewhere in the menuMain.ctp template as well. This fix corrects the alleged typo.