### PR TITLE
Adjusted pagination to use the correct page url

### DIFF
--- a/app/View/Elements/pagination.ctp
+++ b/app/View/Elements/pagination.ctp
@@ -109,7 +109,7 @@
   <form id="limit-page"
         class="pagination-form"
         method="get"
-        onsubmit="limitPage(this.pageLimit.value,recordCount,currentPage); return false;">
+        onsubmit='limitPage(<?php echo json_encode($this->Paginator->url()); ?>,this.pageLimit.value,recordCount,currentPage); return false;'>
     <label for="pageLimit"><?php print _txt('fd.page.limit.display'); ?></label>
     <select name="pageLimit" id="pageLimit">
       <option value="25">25</option>

--- a/app/webroot/js/comanage.js
+++ b/app/webroot/js/comanage.js
@@ -216,7 +216,7 @@ function gotoPage(pageNumber,maxPage,intErrMsg,maxErrMsg) {
 // pageLimit         - page limit                            (int, required)
 // recordCount       - total number of records returned      (int, requried)
 // currentPage       - current page number                   (int, required)
-function limitPage(pageLimit,recordCount,currentPage) {
+function limitPage(currentUrl, pageLimit,recordCount,currentPage) {
   var limit = parseInt(pageLimit,10);
   var count = parseInt(recordCount,10);
   var page = parseInt(currentPage,10);
@@ -228,7 +228,6 @@ function limitPage(pageLimit,recordCount,currentPage) {
   }
 
   // Add the new limit parameter to the url
-  var currentUrl =  window.location.pathname;
   currentUrl = currentUrl.replace(new RegExp('\/limit:[0-9]*', 'g'), '')+'/limit:' + limit;
 
   // Test to see if the new limit allows the current page to exist


### PR DESCRIPTION
instead of the window.location, which may be different for implicit URLs like index pages, we now pass the Paginator->url(), which is used in other places in the paginator output.