### PR TITLE
Co 1856 Canvas displays View button for identifiers when it should not for non-admins

### DIFF
--- a/app/Controller/CoDepartmentsController.php
+++ b/app/Controller/CoDepartmentsController.php
@@ -144,6 +144,11 @@ class CoDepartmentsController extends StandardController {
     // View an existing CO Department?
     $p['view'] = ($roles['cmadmin'] || $roles['coadmin'] || $roles['comember']);
 
+    // View identifiers? This correlates with IdentifiersController
+    $p['identifiers'] = ($roles['cmadmin']
+                         || $roles['coadmin']
+                         || ($managed && $roles['couadmin']));
+
     $this->set('permissions', $p);
     return $p[$this->action];
   }

--- a/app/Controller/CoPeopleController.php
+++ b/app/Controller/CoPeopleController.php
@@ -669,6 +669,11 @@ class CoPeopleController extends StandardController {
     // If we're an admin, we act as an admin, not self.
     $p['editself'] = $self && !$roles['cmadmin'] && !$roles['coadmin'] && !$roles['couadmin'];
     
+    // View identifiers? This correlates with IdentifiersController
+    $p['identifiers'] = ($roles['cmadmin']
+                         || $roles['coadmin']
+                         || ($managed && $roles['couadmin']));
+    
     // View history? This correlates with HistoryRecordsController
     $p['history'] = ($roles['cmadmin']
                      || $roles['coadmin']

--- a/app/Controller/OrgIdentitiesController.php
+++ b/app/Controller/OrgIdentitiesController.php
@@ -551,6 +551,11 @@ class OrgIdentitiesController extends StandardController {
       // Find an Org Identity to add to a CO?
       $p['find'] = ($roles['cmadmin'] || $roles['coadmin'] || $roles['couadmin']);
       
+      // View identifiers? This correlates with IdentifiersController
+      $p['identifiers'] = ($roles['cmadmin']
+                           || $roles['coadmin']
+                           || ($managed && $roles['couadmin']));
+      
       // View history? This correlates with HistoryRecordsController
       $p['history'] = ($roles['cmadmin']
                        || ($managed && ($roles['coadmin'] || $roles['couadmin'])));

--- a/app/View/Elements/mvpa.ctp
+++ b/app/View/Elements/mvpa.ctp
@@ -165,14 +165,19 @@
             if(!empty($mvpa_format) && function_exists($mvpa_format)) {
               $displaystr = $mvpa_format($m);
             }
-            
-            // Render the text link
+
             print '<li class="field-data-container">';
             print '<div class="field-data">';
-            print $this->Html->link($displaystr,
-                                    array('controller' => $lmvpapl,
-                                          'action' => $laction,
-                                          $m['id']));
+            if (($mvpa_model == 'Identifier') && !$permissions['identifiers'] ) {
+              print $displaystr;
+            } else {
+              // Render the text link
+              print $this->Html->link($displaystr,
+                                      array('controller' => $lmvpapl,
+                                            'action' => $laction,
+                                            $m['id']));
+            }
+            
             print "&nbsp;(" . $typestr . ")\n";
             print '</div>';
             print '<div class="field-actions">';
@@ -189,13 +194,16 @@
               }
             }
             
-            // This renders the View or Edit button, as appropriate
-            print $this->Html->link(_txt('op.'.$laction),
-                                    array(
-                                      'controller' => $lmvpapl,
-                                      'action' => $laction,
-                                      $m['id']),
-                                    array('class' => $laction.'button')) . "\n";
+            if (($mvpa_model != 'Identifier') || 
+               (($mvpa_model == 'Identifier') && $permissions['identifiers'])) {
+              // This renders the View or Edit button, as appropriate
+              print $this->Html->link(_txt('op.'.$laction),
+                                      array(
+                                        'controller' => $lmvpapl,
+                                        'action' => $laction,
+                                        $m['id']),
+                                      array('class' => $laction.'button')) . "\n";
+            }
             
             // Possibly render a delete button
             if($laction == 'edit' && $editable) {


### PR DESCRIPTION
This PR fixes CO-1856 [Canvas displays View button for identifiers when it should not for non-admins]

## The Bug: 

The `mvpa.ctp` template renders a link out to an "Identifier" view without checking if the user has permissions to view the url.

## The Existing Architecture 

There are three pages that use the template to render Identifiers [CoDepartments, CoPeople, and OrgIdentities]. The section of the template that renders the link does so twice, creating a link out of the name of the identifier, and rendering a view button. These sections are also rendered for other types of models besides identifiers, in which case the links are legitimate and should still be shown.

## The Solution

An additional permission 'identifiers' is added to each of the three controllers, following the existing permission pattern found in the controller, and copying the permission logic from the Identifiers controller.  In the template the links are not rendered if the model is an identifier and the user does not have permission. All other conditions should follow existing logic.

## Testing and Verification

As both an admin and as an enrolled user, view the user's Profile, their Org Identity, and a Department with an Identifier.  The admin should have links via the Identifier names, and a rendered edit button. The user should see the name as plain text and no view button.  The user should still have links in the Email Addresses section (and URLs if any are present).

### Profile:
![profile](https://user-images.githubusercontent.com/1138350/79876856-8f06d700-83b9-11ea-8259-ac29b74517cb.png)
### Org Identity:
![org-identity](https://user-images.githubusercontent.com/1138350/79876851-8dd5aa00-83b9-11ea-9f98-b59fed9a51f9.png)
### Department:
![departments](https://user-images.githubusercontent.com/1138350/79876847-8d3d1380-83b9-11ea-8537-aaadc32d4270.png)

## Areas for Improvement

1. This solution requires duplicate code to be added to multiple controllers, which isn't very DRY.  Perhaps someone could point me to another pattern we have in place to better centralize permissions and avoid the need for duplication.

2. The `$mvpa_model` specific logic in the template is working against the nature of the partial as a place to render models following a common pattern, perhaps there would be a way to push this logic back towards the models themselves.

3. WAVE suggests that the two links are redundant, perhaps we should find this pattern throughout the app and remove either the text or button link.

![Screen Shot 2020-04-21 at 10 08 29 AM](https://user-images.githubusercontent.com/1138350/79879866-42bd9600-83bd-11ea-9319-4a8dfb8dbeed.png)

