### PR TITLE
CO-951_Allow_Null_COU

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -2555,6 +2555,7 @@
     <field name="disable_ois_sync" type="L" />
     <field name="group_validity_sync_window" type="I" />
     <field name="enable_normalization" type="L" />
+    <field name="enable_empty_cou" type="L" />
     <field name="invitation_validity" type="I" />
     <field name="permitted_fields_name" type="C" size="160" />
     <field name="required_fields_addr" type="C" size="160" />

--- a/app/Controller/CoEnrollmentAttributesController.php
+++ b/app/Controller/CoEnrollmentAttributesController.php
@@ -213,17 +213,20 @@ class CoEnrollmentAttributesController extends StandardController {
             
             $this->set('vv_ext_attr_types',
                        $this->CoEnrollmentAttribute->CoEnrollmentFlow->Co->CoExtendedAttribute->find('list', $args));
-            
-            // Assemble the list of available COUs
-            
-            $this->set('vv_cous', $this->CoEnrollmentAttribute->CoEnrollmentFlow->Co->Cou->allCous($coid));
-            
+
             // Assemble the list of available affiliations
             
             $this->set('vv_affiliations', $this->CoPersonRole->types($coid, 'affiliation'));
-            
+
+            // (Dis)allow empty COUs
+
+            $this->set('vv_allow_empty_cou', $this->CoEnrollmentAttribute
+                                                  ->CoEnrollmentFlow
+                                                  ->Co
+                                                  ->CoSetting->emptyCouEnabled($this->cur_co['Co']['id']));
+
             $mode = $this->CoEnrollmentAttribute->CoEnrollmentFlow->Co->CoSetting->getSponsorEligibility($this->cur_co['Co']['id']);
-            
+
             $this->set('vv_sponsor_mode', $mode);
             
             if($mode != SponsorEligibilityEnum::None) {
@@ -428,6 +431,17 @@ class CoEnrollmentAttributesController extends StandardController {
     
     // Edit an existing CO Enrollment Attribute?
     $p['edit'] = ($roles['cmadmin'] || $roles['coadmin']);
+
+    // Determine which COUs a person can manage.
+    if($roles['cmadmin'] || $roles['coadmin']) {
+      // Note that here we get id => name while in CoPeopleController we just
+      // get a list of names. This is to generate the pop-up on the edit form.
+      $p['cous'] = $this->CoPersonRole->Cou->allCous($this->cur_co['Co']['id']);
+    } elseif(!empty($roles['admincous'])) {
+      $p['cous'] = $roles['admincous'];
+    } else {
+      $p['cous'] = array();
+    }
 
     // Edit an existing CO Enrollment Attribute's order?
     $p['order'] = ($roles['cmadmin'] || $roles['coadmin']);

--- a/app/Controller/CoPersonRolesController.php
+++ b/app/Controller/CoPersonRolesController.php
@@ -244,7 +244,11 @@ class CoPersonRolesController extends StandardController {
 
   public function beforeRender() {
     parent::beforeRender();
-    
+
+    $emptyCousPermit = $this->CoPersonRole
+                            ->CoPerson
+                            ->Co
+                            ->CoSetting->emptyCouEnabled($this->cur_co['Co']['id']);
     if(!$this->request->is('restful')){
       // Mappings for extended types
       $this->set('vv_addresses_types', $this->CoPersonRole->Address->types($this->cur_co['Co']['id'], 'type'));
@@ -285,6 +289,8 @@ class CoPersonRolesController extends StandardController {
       
       // Extended attributes
       $this->set('vv_extended_attributes', $this->extended_attributes);
+      // (Dis)allow Empty COUs
+      $this->set('vv_allow_empty_cou', $emptyCousPermit);
     }
   }
   

--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -531,6 +531,11 @@ class CoPetitionsController extends StandardController {
         }
         
         $this->set('co_enrollment_attributes', $enrollmentAttributes);
+        // (Dis)allow empty COUs
+        $this->set('vv_allow_empty_cou', $this->CoPetition
+                                              ->CoEnrollmentFlow
+                                              ->Co
+                                              ->CoSetting->emptyCouEnabled($this->cur_co['Co']['id']));
       }
       
       if(in_array($this->action, array('petitionerAttributes', 'view'))) {

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1155,6 +1155,7 @@ original notification at
   'fd.de.race'    =>  'Race',
   'fd.de.disab'   =>  'Disability',
   'fd.de.enable'  =>  'Enable NSF Demographics',
+  'fd.cou_empty.enable'  =>  'Enable Empty COUs',
   'fd.default'    =>  'Default',
   'fd.date_of_birth' => 'Date of Birth',
   'fd.dp.group.admin' => 'Administrative Group',

--- a/app/Model/CoEnrollmentAttribute.php
+++ b/app/Model/CoEnrollmentAttribute.php
@@ -117,6 +117,14 @@ class CoEnrollmentAttribute extends AppModel {
   
   /**
    * Determine the attributes available to be requested as part of an Enrollment Flow.
+   * (1)  (code=r) Single valued CO Person Role attributes
+   * (2)  (code=p) Multi valued CO Person attributes
+   * (2a) (code=g) Group Memberships are Multi valued CO Person attributes, but have all sorts of special logic around them so they get their own code
+   * (3)  (code=m) Multi valued CO Person Role attributes
+   * (4)  (code=x) CO Person Role Extended attributes
+   * (5)  (code=o) Single valued Org Identity attributes, if enabled
+   * (6)  (code=i) Multi valued Org Identity attributes, if enabled.Note that since org identities don't support extended types, we use default values here.
+   * (7)  (code=e) Enrollment Flow specific attributes -- these don't get copied out of the petition
    *
    * @since  COmanage Registry v0.3
    * @param  integer Identifier of the CO to assemble attributes for
@@ -261,8 +269,9 @@ class CoEnrollmentAttribute extends AppModel {
     // the flow changes after the petition is created), but Enrollment Attributes stay
     // with the current flow definition. So we need to check if there is a parent id.
     $actualEfId = $this->CoEnrollmentFlow->field('co_enrollment_flow_id', array('CoEnrollmentFlow.id' => $coef));
-    
-    if(!$actualEfId) {
+
+    // if there is no parent id then the co_enrollment_flow_id field will always be null
+    if(is_null($actualEfId)) {
       $actualEfId = $coef;
     }
     
@@ -339,17 +348,21 @@ class CoEnrollmentAttribute extends AppModel {
         // type 'o' or 'r' and is required by the data model.
         $attr['required'] = $efAttr['CoEnrollmentAttribute']['required'];
         $attr['mvpa_required'] = false; // does not apply
-        
-        if(($attrCode == 'o' || $attrCode == 'r')
-           && $attrModel->validate[$attrName]['content']['required'])
-          $attr['required'] = true;
+
+        // We check if the attribute is requested by the Model's validation rules
+        // If this is true then it does not matter if we choose required or not
+        // Also it does not matter if we want it empty or not
+        if( $attrCode == 'o' || $attrCode == 'r') {
+          $attr['required'] = (bool)$attrModel->validate[$attrName]['content']['required'];
+          $attr['allow_empty'] = (bool)$attrModel->validate[$attrName]['content']['allowEmpty'];
+        }
         
         // Label
         $attr['label'] = $efAttr['CoEnrollmentAttribute']['label'];
         
         // Description
         $attr['description'] = $efAttr['CoEnrollmentAttribute']['description'];
-        
+
         // Single value attributes are never hidden, unless there is a non-modifable
         // default value
         $attr['hidden'] =
@@ -425,14 +438,13 @@ class CoEnrollmentAttribute extends AppModel {
           } else {
             $attr['default'] = $efAttr['CoEnrollmentAttributeDefault'][0]['value'];
           }
-          
           $attr['modifiable'] = $efAttr['CoEnrollmentAttributeDefault'][0]['modifiable'];
         } elseif($efAttr['CoEnrollmentAttribute']['attribute'] == 'r:sponsor_co_person_id') {
           // Special case for sponsor, we want to make sure the modifiable field passes
           // through even if there is no default value
           $attr['modifiable'] = $efAttr['CoEnrollmentAttributeDefault'][0]['modifiable'];
         }
-        
+
         // Attach the validation rules so the form knows how to render the field.
         if($attrCode == 'o') {
           $attr['validate'] = $attrModel->validate[$attrName];
@@ -460,13 +472,23 @@ class CoEnrollmentAttribute extends AppModel {
             $args['joins'][0]['type'] = 'INNER';
             $args['joins'][0]['conditions'][0] = 'Cou.co_id=CoEnrollmentFlow.co_id';
             $args['order'] = 'Cou.name ASC';
-            
+
             $attr['select'] = $this->CoEnrollmentFlow->CoPetition->Cou->find('list', $args);
             $attr['validate']['content']['rule'][0] = 'inList';
             $attr['validate']['content']['rule'][1] = array_keys($attr['select']);
             // As of Cake 2.1, inList doesn't work for integers unless you set strict to false
             // https://cakephp.lighthouseapp.com/projects/42648/tickets/2770-inlist-doesnt-work-more-in-21
             $attr['validate']['content']['rule'][2] = false;
+            if(isset($efAttr['CoEnrollmentAttributeDefault'][0]['value'])
+               && !is_null($efAttr['CoEnrollmentAttributeDefault'][0]['value'])) {
+              $attr['default'] = $efAttr['CoEnrollmentAttributeDefault'][0]['value'];
+              // If there's a default value, then the attribute can be hidden
+              $attr['hidden'] = (isset($efAttr['CoEnrollmentAttribute']['hidden'])
+                && $efAttr['CoEnrollmentAttribute']['hidden']);
+            }
+            $attr['modifiable'] = (isset($efAttr['CoEnrollmentAttributeDefault'][0]['modifiable'])
+                                    ? $efAttr['CoEnrollmentAttributeDefault'][0]['modifiable']
+                                    : false);
           } elseif($attrName == 'sponsor_co_person_id') {
             // Like COU ID, we need to set up a select
             
@@ -896,7 +918,7 @@ class CoEnrollmentAttribute extends AppModel {
     if(!empty($envValues)) {
       $eaMap = array();
       
-      for($i = 0;$i < count($enrollmentAttributes);$i++) {
+      for($i = 0, $iMax = count($enrollmentAttributes); $i < $iMax; $i++) {
         $model = explode('.', $enrollmentAttributes[$i]['model'], 2);
         
         // Only track org identity attributes
@@ -955,8 +977,8 @@ class CoEnrollmentAttribute extends AppModel {
     }
     
     // Check for default values from env variables.
-    
-    for($i = 0;$i < count($enrollmentAttributes);$i++) {
+
+    for($i = 0, $iMax = count($enrollmentAttributes); $i < $iMax; $i++) {
       // Skip anything that's hidden. This will prevent us from setting a
       // default value for metadata attributes, and will also prevent using
       // default values in hidden attributes (which is probably a feature, not

--- a/app/Model/CoSetting.php
+++ b/app/Model/CoSetting.php
@@ -84,6 +84,11 @@ class CoSetting extends AppModel {
       'required' => false,
       'allowEmpty' => true
     ),
+    'enable_empty_cou' => array(
+      'rule' => 'boolean',
+      'required' => false,
+      'allowEmpty' => true
+    ),
     'invitation_validity' => array(
       'rule' => 'numeric',
       'required' => false,
@@ -155,7 +160,8 @@ class CoSetting extends AppModel {
     'required_fields_name'       => RequiredNameFieldsEnum::Given,
     'sponsor_co_group_id'        => null,
     'sponsor_eligibility'        => SponsorEligibilityEnum::CoOrCouAdmin,
-    't_and_c_login_mode'         => TAndCLoginModeEnum::NotEnforced
+    't_and_c_login_mode'         => TAndCLoginModeEnum::NotEnforced,
+    'enable_empty_cou'           => false,
   );
   
   /**
@@ -392,10 +398,22 @@ class CoSetting extends AppModel {
    * @param  integer $coId CO ID
    * @return boolean True if enabled, false otherwise
    */
-  
+
   public function oisSyncEnabled($coId) {
     // Note we flip the value. The data model specifies "disabled" so that
     // the default (ie: no value present in the table) is enabled.
     return !$this->lookupValue($coId, 'disable_ois_sync');
+  }
+
+  /**
+   * Determine if Empty COUs are enabled for the specified CO.
+   *
+   * @since  COmanage Registry v3.3.0
+   * @param  integer $coId CO ID
+   * @return boolean True if enabled, false otherwise
+   */
+
+  public function emptyCouEnabled($coId) {
+    return (boolean)$this->lookupValue($coId, 'enable_empty_cou');
   }
 }

--- a/app/View/CoEnrollmentAttributes/fields.inc
+++ b/app/View/CoEnrollmentAttributes/fields.inc
@@ -541,10 +541,12 @@
               <select name="def_cou_val"
                       id="def_cou_val"
                       onchange="set_attr_def_value('def_cou_val')">
-                <option value=""></option>
-                <?php foreach(array_keys($vv_cous) as $k): ?>
+                <?php if($vv_allow_empty_cou): ?>
+                  <option value=""></option>
+                <?php endif;?>
+                <?php foreach($permissions['cous'] as $k => $value): ?>
                   <option value="<?php print filter_var($k,FILTER_SANITIZE_SPECIAL_CHARS); ?>">
-                    <?php print filter_var($vv_cous[$k],FILTER_SANITIZE_SPECIAL_CHARS); ?>
+                    <?php print filter_var($value,FILTER_SANITIZE_SPECIAL_CHARS); ?>
                   </option>
                 <?php endforeach; ?>
               </select>

--- a/app/View/CoPersonRoles/fields.inc
+++ b/app/View/CoPersonRoles/fields.inc
@@ -101,6 +101,9 @@
 
       $('#CoPersonRoleCouId').on('change', '', function () {
         var selectedCOU = $(this).children("option:selected").html();
+        if(selectedCOU.trim() === "") {
+          selectedCOU = '<?php print $cur_cou;?>';
+        }
         $("label[for='CoPersonRoleAffiliation']").text(selectedCOU + ' Affiliation');
         $("label[for='CoPersonRoleTitle']").text(selectedCOU + ' Title');
       });
@@ -175,7 +178,7 @@
                     $attrs['value'] = (isset($co_person_roles[0]['CoPersonRole']['cou_id'])
                       ? $co_person_roles[0]['CoPersonRole']['cou_id']
                       : 0);
-                    $attrs['empty'] = false;
+                    $attrs['empty'] = $vv_allow_empty_cou;
 
                     if($e && !$es) {
                       print $this->Form->select('cou_id',

--- a/app/View/CoPetitions/petition-attributes.inc
+++ b/app/View/CoPetitions/petition-attributes.inc
@@ -314,6 +314,11 @@
                 $args['value'] = $ea['default'];
                 $args['disabled'] = !$ea['modifiable'];
               }
+
+              // Calculate what we should do for the COU field
+              if(strpos($fieldName, 'cou_id') !== false){
+                $ea['required'] = !($ea['allow_empty'] && $vv_allow_empty_cou);
+              }
               $args['empty'] = !$ea['required'];
               $args['class'] = 'co-selectfield';
               $args['aria-label'] = $m;

--- a/app/View/CoSettings/fields.inc
+++ b/app/View/CoSettings/fields.inc
@@ -135,6 +135,19 @@
   </li>
   <li>
     <div class="field-name">
+        <div class="field-title"><?php print _txt('fd.cou_empty.enable'); ?></div>
+    </div>
+    <div class="field-info checkbox">
+        <?php print ($e
+                     ? $this->Form->input('enable_empty_cou')
+                     : (isset($co_settings[0]['CoSetting']['enable_empty_cou'])
+                        && $co_settings[0]['CoSetting']['enable_empty_cou']
+                        ? _txt('fd.yes') : _txt('fd.no')));
+              print ' ' . $this->Form->label('enable_empty_cou',_txt('fd.cou_empty.enable'));
+        ?>
+  </li>
+  <li>
+    <div class="field-name">
       <div class="field-title"><?php print $this->Form->label('invitation_validity',_txt('fd.ef.invval'),array('class' => 'fieldTitle'));?></div>
       <div class="field-desc"><?php print _txt('fd.ef.invval.desc'); ?></div>
     </div>


### PR DESCRIPTION
Added support for Empty COUs
Scenarios tested:
- Add empty named COU manually from inside CO Person's profile
- Choose an empty COU name when configuring an Enrollment flow
- Choose an empty COU name when collecting user's attributes

_Upgrade guide in COmanage wiki should be updated as well._

Should we:
- ~~Advise the user to hide the COU field if s/he has as a default COU name value the empty one and has the modifiable configuration disabled? **- Declined**~~
- enable copying the attributes of a non-empty COU to the empty COU during enrollment? **- Develop this as a Plugin(Enrollee plugin)**