### PR TITLE
CO-1885 handle nested group membership on expunge

### DIFF
--- a/app/Model/CoPerson.php
+++ b/app/Model/CoPerson.php
@@ -305,10 +305,15 @@ class CoPerson extends AppModel {
 				$records = $Model->find('all', array(
 					'conditions' => $conditions, 'fields' => $Model->primaryKey
 				));
-
-				if (!empty($records)) {
+        
+        if (!empty($records)) {
 					foreach ($records as $record) {
-						$Model->delete($record[$Model->alias][$Model->primaryKey]);
+            $currentRecord = $Model->find('first', array(
+              'conditions' => array('id' => $record[$Model->alias][$Model->primaryKey])
+            ));
+            if (!current($currentRecord)['deleted']) {
+              $Model->delete($record[$Model->alias][$Model->primaryKey]);
+            }
 					}
 				}
 			}

--- a/app/Model/CoPerson.php
+++ b/app/Model/CoPerson.php
@@ -307,7 +307,7 @@ class CoPerson extends AppModel {
 				));
         
         if (!empty($records)) {
-					foreach ($records as $record) {
+          foreach ($records as $record) {
             $currentRecord = $Model->find('first', array(
               'conditions' => array('id' => $record[$Model->alias][$Model->primaryKey])
             ));


### PR DESCRIPTION
In testing, I found that the deleteDependent function (used by the CoPerson expunge) gathers up all CoGroupMember records, then deletes them in order.  The beforeDelete throws an error on trying to delete the Parent membership associated with a nested group membership, saying 'Record is already marked deleted.' 

That record was deleted in the afterDelete cleanup associated with the nested group membership's initial deletion - via the syncNestedMembership function (https://github.com/Internet2/comanage-registry/blob/develop/app/Model/CoGroupMember.php#L202).  

So!  To fix this (and also hopefully escape any other delete conflicts on expunge moving forward), let's check whether a record has already been cleaned up before trying to delete it.  