### PR TITLE
CO-1896: Fix global search to focus on opening and submit on enter key

### DIFF
--- a/app/View/Elements/javascript.ctp
+++ b/app/View/Elements/javascript.ctp
@@ -98,13 +98,13 @@
     // USER MENU BEHAVIORS
     // Toggle the global search box
     $("#global-search-toggle").click(function (e) {
-      e.preventDefault();
       e.stopPropagation();
       if ($("#global-search-box").is(":visible")) {
         $("#global-search-box").hide();
         $(this).attr("aria-expanded","false");
       } else {
         $("#global-search-box").show();
+        $("#global-search-box .input input[type='text']").focus();
         $(this).attr("aria-expanded","true");
       }
     });

--- a/app/View/Elements/menuUser.ctp
+++ b/app/View/Elements/menuUser.ctp
@@ -40,7 +40,7 @@
       );
       print $this->Form->create('CoDashboard', $options);
       print $this->Form->label('q', '<span class="visuallyhidden">' . _txt('op.search')
-        . '</span><button id="global-search-toggle" aria-expanded="false" class="cm-toggle"><em class="material-icons">search</em></button>');
+        . '</span><button type="button" id="global-search-toggle" aria-expanded="false" class="cm-toggle"><em class="material-icons">search</em></button>');
       print '<div id="global-search-box" style="display: none;">';
       $options = array(
         'label' => false,


### PR DESCRIPTION
CO-1896: This fixes an issue where the form would not submit when a user hit the enter key after entering their search term. It also fixes the fact that the search input was not focused when the dropdown opened up.