### PR TITLE
Co 1459 Do Not Send Notifications to Expired Users

### DIFF
--- a/app/Model/Behavior/ChangelogBehavior.php
+++ b/app/Model/Behavior/ChangelogBehavior.php
@@ -634,19 +634,8 @@ class ChangelogBehavior extends ModelBehavior {
               
               $ret[$k]['order'] = $v2;
             } elseif(is_array($v2)) {
-              //This recursive modifyContain will successfully add those conditions to a nested contain
-              $ret[$k][$k2] = $this->modifyContain($model->$k->$k2, $v2);
               
-              if(is_string($k2) && !is_integer($k2)) {
-                $cparentfk = Inflector::underscore($model->$k->$k2->name) . "_id";
-                
-                // This will then overwrite any existing conditions, and these conditions were already added in line
-                // 638 by the recursive modifyContain
-                // $ret[$k][$k2]['conditions'] = array(
-                //   $k2.'.'.$cparentfk => null,
-                //   $k2.'.deleted IS NOT true'
-                // );
-              }
+              $ret[$k][$k2] = $this->modifyContain($model->$k->$k2, $v2);
             } elseif(isset($model->$k->$k2)) {
               // Fifth example
               $m = $this->modifyContain($model->$k, array($k2 => $v2));

--- a/app/Model/Behavior/ChangelogBehavior.php
+++ b/app/Model/Behavior/ChangelogBehavior.php
@@ -584,7 +584,7 @@ class ChangelogBehavior extends ModelBehavior {
         // eg: $query['contain'] = array('Model1' => array('Model2'));
         // eg: $query['contain'] = array('Model1' => 'Model2');
         // eg: $query['contain'] = array('conditions' => array('Model1.foo =' => 'value'));
-        // eg: $query['contain'] = array('Model1' => array('conditions' => array('Model1.foo' => 'value),
+        // eg: $query['contain'] = array('Model1' => array('conditions' => array('Model1.foo' => 'value'),
         //                                                 'Model2' => array('conditions' => array('Model2.foo' => 'value'))
         // eg: $query['contain'] = array('Model1' => array('Model2' => 'Model3'));
         // eg: $query['contain'] = array('Model1' => array('order' => 'Model1.field DESC'));
@@ -636,6 +636,15 @@ class ChangelogBehavior extends ModelBehavior {
             } elseif(is_array($v2)) {
               
               $ret[$k][$k2] = $this->modifyContain($model->$k->$k2, $v2);
+              
+              if(is_string($k2) && !is_integer($k2)) {
+                $cparentfk = Inflector::underscore($model->$k->$k2->name) . "_id";
+                
+                $ret[$k][$k2]['conditions'] = array(
+                  $k2.'.'.$cparentfk => null,
+                  $k2.'.deleted IS NOT true'
+                );
+              }
             } elseif(isset($model->$k->$k2)) {
               // Fifth example
               $m = $this->modifyContain($model->$k, array($k2 => $v2));

--- a/app/Model/Behavior/ChangelogBehavior.php
+++ b/app/Model/Behavior/ChangelogBehavior.php
@@ -634,15 +634,18 @@ class ChangelogBehavior extends ModelBehavior {
               
               $ret[$k]['order'] = $v2;
             } elseif(is_array($v2)) {
+              //This recursive modifyContain will successfully add those conditions to a nested contain
               $ret[$k][$k2] = $this->modifyContain($model->$k->$k2, $v2);
               
               if(is_string($k2) && !is_integer($k2)) {
                 $cparentfk = Inflector::underscore($model->$k->$k2->name) . "_id";
                 
-                $ret[$k][$k2]['conditions'] = array(
-                  $k2.'.'.$cparentfk => null,
-                  $k2.'.deleted IS NOT true'
-                );
+                // This will then overwrite any existing conditions, and these conditions were already added in line
+                // 638 by the recursive modifyContain
+                // $ret[$k][$k2]['conditions'] = array(
+                //   $k2.'.'.$cparentfk => null,
+                //   $k2.'.deleted IS NOT true'
+                // );
               }
             } elseif(isset($model->$k->$k2)) {
               // Fifth example

--- a/app/Model/Behavior/ChangelogBehavior.php
+++ b/app/Model/Behavior/ChangelogBehavior.php
@@ -633,7 +633,7 @@ class ChangelogBehavior extends ModelBehavior {
               // Sixth example
               
               $ret[$k]['order'] = $v2;
-            } elseif(is_array($v2)) {  
+            } elseif(is_array($v2)) {
               $ret[$k][$k2] = $this->modifyContain($model->$k->$k2, $v2);
               
               if(is_string($k2) && !is_integer($k2)) {

--- a/app/Model/Behavior/ChangelogBehavior.php
+++ b/app/Model/Behavior/ChangelogBehavior.php
@@ -633,8 +633,7 @@ class ChangelogBehavior extends ModelBehavior {
               // Sixth example
               
               $ret[$k]['order'] = $v2;
-            } elseif(is_array($v2)) {
-              
+            } elseif(is_array($v2)) {  
               $ret[$k][$k2] = $this->modifyContain($model->$k->$k2, $v2);
               
               if(is_string($k2) && !is_integer($k2)) {

--- a/app/Model/CoNotification.php
+++ b/app/Model/CoNotification.php
@@ -599,8 +599,9 @@ class CoNotification extends AppModel {
             )
           ),
           'CoPerson' => array(
-            // We only want active people
-            'conditions' => array('CoPerson.status' => StatusEnum::Active),
+            // We only want active people BUT this condition seems to get overwritten
+            // in ChangelogBehavior (beforeFind - modifyContain) and is therefore not applied
+            // 'conditions' => array('CoPerson.status' => StatusEnum::Active),
             'EmailAddress'
           )
         )
@@ -610,7 +611,8 @@ class CoNotification extends AppModel {
       
       if(!empty($gr['CoGroupMember'])) {
         foreach($gr['CoGroupMember'] as $gm) {
-          if(!empty($gm['CoPerson'])) {
+          if(!empty($gm['CoPerson']) 
+            && $gm['CoPerson']['status'] == StatusEnum::Active) {
             // Move EmailAddress up a level, as for 'coperson'
             $recipients[] = array(
               'RecipientCoPerson' => $gm['CoPerson'],


### PR DESCRIPTION
This beforeFind method is being called prior to running the query in CoNotification on line 609 (https://github.com/Internet2/comanage-registry/blob/develop/app/Model/CoNotification.php#L609).  

This particular elseif is being applied to the nested CoPerson contain (that is included within the CoGroupMember, which is contained within the CoGroup).  Here, a recursive call is done to modifyContain to walk through the CoPerson. 

Prior to the recursive call, the conditions for the CoPerson look like this: 
`'conditions' => array(
		'CoPerson.status' => 'A'
	)`

After the recursive call, the required new conditions of a null co_person_id and non deleted status are merged with the original Active conditions correctly: 
`'conditions' => array(
		'CoPerson.co_person_id' => null,
		(int) 0 => 'CoPerson.deleted IS NOT true',
		'CoPerson.status' => 'A'
	)`

Then, the conditions are changed again by being hard set to the additional required behaviors https://github.com/Internet2/comanage-registry/blob/develop/app/Model/Behavior/ChangelogBehavior.php#L642): 
`'conditions' => array(
		'CoPerson.co_person_id' => null,
		(int) 0 => 'CoPerson.deleted IS NOT true'
	)`

This is where the Active status condition is dropped.  I investigated instead merging any existing conditions with the new conditions, but you end up with an issue of duplicate conditions: 
`array(
	'CoPerson.co_person_id' => null,
	(int) 0 => 'CoPerson.deleted IS NOT true',
	'CoPerson.status' => 'A',
	(int) 1 => 'CoPerson.deleted IS NOT true'
)`

Because the recursive modifyContain call is correctly adding those conditions, let's remove the additional hard reset on those conditions.  
