### PR TITLE
CO-1549 Search results display duplicates if the person has official and preferred names

### DIFF
--- a/app/Controller/CoPeopleController.php
+++ b/app/Controller/CoPeopleController.php
@@ -37,6 +37,7 @@ class CoPeopleController extends StandardController {
   
   public $paginate = array(
     'limit' => 25,
+    // CO-1549. Group By CoPerson.id ensures duplicate users are not returned after joining with other tables (such as cm_names).
     'group' => array(
       'CoPerson.id', 'Co.id', 'PrimaryName.id'
     ),

--- a/app/Controller/CoPeopleController.php
+++ b/app/Controller/CoPeopleController.php
@@ -37,6 +37,9 @@ class CoPeopleController extends StandardController {
   
   public $paginate = array(
     'limit' => 25,
+    'group' => array(
+      'CoPerson.id', 'Co.id', 'PrimaryName.id'
+    ),
     'order' => array(
       'PrimaryName.family' => 'asc',
       'PrimaryName.given' => 'asc'


### PR DESCRIPTION
Adding a group by CoPerson.id will ensure that no duplicate records are returned from the CoPerson paginate query.  (Some examples here: https://book.cakephp.org/1.3/en/The-Manual/Common-Tasks-With-CakePHP/Pagination.html#custom-query-pagination)