### PR TITLE
CO-2093_Logout_redirect_broken_when_URL_includes_query_string

### DIFF
--- a/app/webroot/auth/login/index.php
+++ b/app/webroot/auth/login/index.php
@@ -48,8 +48,10 @@ if(empty($_SESSION["Auth"]["redirect"])) {
 }
 
 $_SESSION['Auth']['external']['user'] = $_SERVER['REMOTE_USER'];
-$path = str_replace('auth/login/', '', $_SERVER["REQUEST_URI"]);
-$redirect_url = $_SERVER["REQUEST_SCHEME"] . '://' . $_SERVER["SERVER_NAME"] . $path . 'users/login';
+$re = '/(.*)\/auth\/login(.*)/m';
+$subst = '$1/users/login$2';
+$redirect_location = preg_replace($re, $subst, $_SERVER["REQUEST_URI"]);
+$redirect_url = $_SERVER["REQUEST_SCHEME"] . '://' . $_SERVER["SERVER_NAME"] . $redirect_location;
 
 ?>
 <!DOCTYPE html>

--- a/app/webroot/auth/logout/index.php
+++ b/app/webroot/auth/logout/index.php
@@ -30,8 +30,11 @@
 
 session_name("CAKEPHP");
 session_start();
-$path = str_replace('auth/logout/', '', $_SERVER["REQUEST_URI"]);
+
+$re = '/(.*)\/auth\/logout(.*)/m';
+$subst = '$1/users/logout$2';
+$redirect_location = preg_replace($re, $subst, $_SERVER["REQUEST_URI"]);
 
 unset($_SESSION['Auth']);
 
-header('Location: ' . $path . 'users/logout');
+header('Location: ' . $redirect_location);


### PR DESCRIPTION
Fix logout redirect broken when URL includes query string