### PR TITLE
Use Application Preferences for Main Menu state handling (CO-1928)

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1031,7 +1031,7 @@ class AppController extends Controller {
 
   /**
    * Get a user's Application Preferences
-   * - postcondition: Application Preferences variable set if Auth.User.co_person_id exists
+   * - postcondition: Application Preferences variable set
    * @since  COmanage Registry v3.3.0
    */
   protected function getAppPrefs() {

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -418,6 +418,7 @@ class AppController extends Controller {
     if(!$this->request->is('restful')) {
       $this->getTheme();
       $this->getUImode();
+      $this->getAppPrefs();
       
       if($this->Session->check('Auth.User.org_identities')) {
         $this->menuAuth();
@@ -1026,6 +1027,37 @@ class AppController extends Controller {
     if(!$this->Session->check('Auth.User.name')) {
       $this->set('vv_ui_mode', EnrollmentFlowUIMode::Basic);
     }
+  }
+
+  /**
+   * Get a user's Application Preferences
+   * - postcondition: Application Preferences variable set if Auth.User.co_person_id exists
+   * @since  COmanage Registry v3.3.0
+   */
+  protected function getAppPrefs() {
+
+    $appPrefs = null;
+    $coPersonId = $this->Session->read('Auth.User.co_person_id');
+
+    // Get preferences if we have an Auth.User.co_person_id
+    if(!empty($coPersonId)) {
+      $this->loadModel('ApplicationPreference');
+      $prefs = array(
+        'co_person_id' => $coPersonId,
+        // value is null if no preferences found
+        'preferences'  => $this->ApplicationPreference->retrieveAll($coPersonId)
+      );
+
+      // If we have data, build an associative array for easy lookups
+      if(!empty($prefs)) {
+        foreach($prefs['preferences'] as $pref) {
+          $appPrefs[$pref['ApplicationPreference']['tag']] = $pref['ApplicationPreference']['value'];
+        }
+      }
+
+    }
+
+    $this->set('vv_app_prefs', $appPrefs);
   }
 
   /**

--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1032,7 +1032,7 @@ class AppController extends Controller {
   /**
    * Get a user's Application Preferences
    * - postcondition: Application Preferences variable set
-   * @since  COmanage Registry v3.3.0
+   * @since  COmanage Registry v4.0.0
    */
   protected function getAppPrefs() {
 
@@ -1042,19 +1042,7 @@ class AppController extends Controller {
     // Get preferences if we have an Auth.User.co_person_id
     if(!empty($coPersonId)) {
       $this->loadModel('ApplicationPreference');
-      $prefs = array(
-        'co_person_id' => $coPersonId,
-        // value is null if no preferences found
-        'preferences'  => $this->ApplicationPreference->retrieveAll($coPersonId)
-      );
-
-      // If we have data, build an associative array for easy lookups
-      if(!empty($prefs)) {
-        foreach($prefs['preferences'] as $pref) {
-          $appPrefs[$pref['ApplicationPreference']['tag']] = $pref['ApplicationPreference']['value'];
-        }
-      }
-
+      $appPrefs = $this->ApplicationPreference->retrieveAll($coPersonId);
     }
 
     $this->set('vv_app_prefs', $appPrefs);

--- a/app/Model/ApplicationPreference.php
+++ b/app/Model/ApplicationPreference.php
@@ -108,13 +108,7 @@ class ApplicationPreference extends AppModel {
     $args['fields'] = array('tag', 'value');
     $args['contain'] = false;
 
-    $prefs = $this->find('list', $args);
-
-    if(!empty($prefs)) {
-      return $prefs;
-    }
-
-    return null;
+    return $this->find('list', $args);
   }
   
   /**

--- a/app/Model/ApplicationPreference.php
+++ b/app/Model/ApplicationPreference.php
@@ -108,7 +108,7 @@ class ApplicationPreference extends AppModel {
     $args['fields'] = array('tag', 'value');
     $args['contain'] = false;
 
-    $prefs = $this->find('all', $args);
+    $prefs = $this->find('list', $args);
 
     if(!empty($prefs)) {
       return $prefs;

--- a/app/Model/ApplicationPreference.php
+++ b/app/Model/ApplicationPreference.php
@@ -98,8 +98,8 @@ class ApplicationPreference extends AppModel {
 
   /**
    * Retrieve all Application Preferences for a user.
-   * @param  int    $coPersonId CO Person ID
-   * @return array|null        Array of values if found, null otherwise
+   * @param  int $coPersonId      CO Person ID
+   * @return array                Array of values (possibly empty)
    */
 
   public function retrieveAll($coPersonId) {

--- a/app/Model/ApplicationPreference.php
+++ b/app/Model/ApplicationPreference.php
@@ -95,6 +95,27 @@ class ApplicationPreference extends AppModel {
     
     return null;
   }
+
+  /**
+   * Retrieve all Application Preferences for a user.
+   * @param  int    $coPersonId CO Person ID
+   * @return array|null        Array of values if found, null otherwise
+   */
+
+  public function retrieveAll($coPersonId) {
+    $args = array();
+    $args['conditions']['ApplicationPreference.co_person_id'] = $coPersonId;
+    $args['fields'] = array('tag', 'value');
+    $args['contain'] = false;
+
+    $prefs = $this->find('all', $args);
+
+    if(!empty($prefs)) {
+      return $prefs;
+    }
+
+    return null;
+  }
   
   /**
    * Store an Application Preference.

--- a/app/View/Elements/javascript.ctp
+++ b/app/View/Elements/javascript.ctp
@@ -122,7 +122,7 @@
         }
       }
 
-      // Save the ID of the most recently expanded menuTop item in a Application Preference 
+      // Save the ID of the most recently expanded menuTop item in an Application Preference
       if ($(this).attr("aria-expanded") == "true") {
         var parentId = $(this).parent().attr("id");
         setApplicationPreference("uiMainMenuSelectedParentId",{"value":parentId});

--- a/app/View/Elements/javascript.ctp
+++ b/app/View/Elements/javascript.ctp
@@ -75,41 +75,27 @@
     $('.focusFirst').focus();
 
     // DESKTOP MENU DRAWER BEHAVIOR
-    // Check the drawer half-closed cookie on first load and set the drawer state appropriately
-    if (Cookies.get("desktop-drawer-state") == "half-closed") {
-      $("#navigation-drawer,#footer-drawer").addClass("half-closed");
-      $("#main").addClass("drawer-half-closed");
-    } else {
-      // Preserve the state of the most recently selected menu item if it is expandable (a "menuTop" item)
-      // (we only use this behavior when the the drawer is fully-open)
-      var mainMenuSelectedParentId = Cookies.get("main-menu-selected-parent-id");
-      if(mainMenuSelectedParentId != undefined && mainMenuSelectedParentId != "") {
-        $("#" + mainMenuSelectedParentId).addClass("active");
-        $("#" + mainMenuSelectedParentId + " > a.menuTop").attr("aria-expanded","true");
-        $("#" + mainMenuSelectedParentId + " > ul").addClass("in");
-      }
-    }
 
     // Hamburger menu-drawer toggle
     $('#co-hamburger').click(function () {
       if($(window).width() < 768) {
         // Mobile mode
-        $("#navigation-drawer,#footer-drawer").removeClass("half-closed").toggle();
+        $("#navigation-drawer").removeClass("half-closed").toggle();
       } else {
         // Desktop mode
         if ($("#navigation-drawer").hasClass("half-closed")) {
-          $("#navigation-drawer,#footer-drawer").removeClass("half-closed");
+          $("#navigation-drawer").removeClass("half-closed");
           $("#main").removeClass("drawer-half-closed");
-          // set a cookie to hold drawer half-open state between requests
-          Cookies.set("desktop-drawer-state", "open");
+          // save user's application preference for drawer state
+          setApplicationPreference("uiDrawerState",{"value":"open"});
         } else {
-          $("#navigation-drawer,#footer-drawer").addClass("half-closed");
+          $("#navigation-drawer").addClass("half-closed");
           $("#main").addClass("drawer-half-closed");
           // ensure all the sub-menus collapse when half-closing the menu
           $("#navigation .metismenu li ul").removeClass("in");
           $("#navigation .metismenu li").removeClass("active");
-          // set a cookie to hold drawer half-open state between requests
-          Cookies.set("desktop-drawer-state", "half-closed");
+          // save user's application preference for drawer state
+          setApplicationPreference("uiDrawerState",{"value":"half-closed"});
         }
       }
     });
@@ -126,16 +112,22 @@
 
     // Desktop half-closed drawer behavior & expandable menu items
     $('#navigation-drawer a.menuTop').click(function () {
-      if (Cookies.get("desktop-drawer-state") == "half-closed") {
-        $("#navigation-drawer").toggleClass("half-closed");
+      // widen the menu while a.menuTop is expanded so we can see the menu items
+      if ($("#navigation-drawer").hasClass("half-closed")) {
+        $("#navigation-drawer").removeClass("half-closed").addClass("intermediate-open");
+      } else {
+        // close it back down if we're in the intermediate state and we close a.menuTop
+        if ($("#navigation-drawer").hasClass("intermediate-open")) {
+          $("#navigation-drawer").removeClass("intermediate-open").addClass("half-closed");
+        }
       }
 
-      // Save the ID of the most recently expanded menuTop item for use on reload
+      // Save the ID of the most recently expanded menuTop item in a Application Preference 
       if ($(this).attr("aria-expanded") == "true") {
         var parentId = $(this).parent().attr("id");
-        Cookies.set("main-menu-selected-parent-id", parentId);
+        setApplicationPreference("uiMainMenuSelectedParentId",{"value":parentId});
       } else {
-        Cookies.set("main-menu-selected-parent-id", "");
+        setApplicationPreference("uiMainMenuSelectedParentId",{"value":null});
       }
     });
 

--- a/app/View/Elements/menuMain.ctp
+++ b/app/View/Elements/menuMain.ctp
@@ -39,6 +39,14 @@ if(!empty($vv_enrollment_flow_cos)) {
   // Convert the list of COs with enrollment flows defined into a more useful format
   $efcos = Hash::extract($vv_enrollment_flow_cos, '{n}.CoEnrollmentFlow.co_id');
 }
+
+// Determine if we have an expanded menu selected but do not expand a menu if the menu drawer is half-closed.
+// Currently this is used only for the two expandable menus in the Main Menu (People and Platform).
+$selectedMenu = "";
+$currentMenu = "";
+if(!empty($vv_app_prefs['uiMainMenuSelectedParentId']) && $vv_app_prefs['uiDrawerState'] != 'half-closed') {
+  $selectedMenu = filter_var($vv_app_prefs['uiMainMenuSelectedParentId'],FILTER_SANITIZE_STRING);
+}
 ?>
 
 <ul id="main-menu" class="metismenu">
@@ -49,14 +57,15 @@ if(!empty($vv_enrollment_flow_cos)) {
       $menuCoId = $cur_co['Co']['id'];
 
       // People Menu
+      $currentMenu = 'peopleMenu';
       if(isset($permissions['menu']['cos']) && $permissions['menu']['cos']) {
-        print '<li id="peopleMenu" class="co-expandable-menu-item">';
-        print '<a class="menuTop" aria-expanded="false" href="#">';
+        print '<li id="peopleMenu" class="co-expandable-menu-item' . ($selectedMenu == $currentMenu ? " active" : "") . '">';
+        print '<a class="menuTop" aria-expanded="' . ($selectedMenu == $currentMenu ? "true" : "false") . '" href="#">';
         print '<em class="material-icons" aria-hidden="true">person</em>';
         print '<span class="menuTitle">' . _txt('me.people') . '</span>';
         print '<span class="fa arrow fa-fw"></span>';
         print '</a>';
-        print '<ul aria-expanded="false" class="collapse">';
+        print '<ul aria-expanded="false" class="collapse' . ($selectedMenu == $currentMenu ? " in" : "") . '">';
         print '<li>';
         $args = array();
         $args['plugin'] = null;
@@ -438,14 +447,15 @@ if(!empty($vv_enrollment_flow_cos)) {
     // END Configuration Menu
 
     // Platform Menu
+    $currentMenu = "platformMenu";
     if(!empty($permissions['menu']['admin']) && $permissions['menu']['admin']) {
-      print '<li id="platformMenu" class="co-expandable-menu-item">';
-      print '<a href="#" class="menuTop" aria-expanded="false">';
+      print '<li id="platformMenu" class="co-expandable-menu-item' . ($selectedMenu == $currentMenu ? " active" : "") . '">';
+      print '<a href="#" class="menuTop" aria-expanded="' . ($selectedMenu == $currentMenu ? "true" : "false") . '">';
       print '<em class="material-icons" aria-hidden="true">build</em>';
       print '<span class="menuTitle">' . _txt('me.platform') . '</span>';
       print '<span class="fa arrow fa-fw"></span>';
       print '</a>';
-      print '<ul aria-expanded="false" class="collapse">';
+      print '<ul aria-expanded="false" class="collapse' . ($selectedMenu == $currentMenu ? " in" : "") . '">';
       
       if($pool_org_identities) {
         print '<li>';

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -218,7 +218,13 @@
 
       <div id="main-wrapper">
         <?php if($vv_ui_mode === EnrollmentFlowUIMode::Full): ?>
-          <div id="navigation-drawer">
+          <?php
+            $navigationDrawerClasses = "coNavDrawer";
+            if(!empty($vv_app_prefs['uiDrawerState'])) {
+              $navigationDrawerClasses .= " " . filter_var($vv_app_prefs['uiDrawerState'],FILTER_SANITIZE_STRING);
+            }
+          ?>
+          <div id="navigation-drawer" class="<?php print $navigationDrawerClasses; ?>">
             <nav id="navigation" aria-label="main menu">
               <?php print $this->element('menuMain'); ?>
               <?php if(!empty($vv_NavLinks) || !empty($vv_CoNavLinks)): ?>
@@ -236,6 +242,9 @@
             if($vv_ui_mode === EnrollmentFlowUIMode::Basic) {
               $mainCssClasses = 'cm-main-basic';
             }
+          }
+          if(!empty($vv_app_prefs['uiDrawerState'])) {
+            $mainCssClasses .= " drawer-" . filter_var($vv_app_prefs['uiDrawerState'],FILTER_SANITIZE_STRING);
           }
         ?>
         <main id="main" class="<?php print $mainCssClasses; ?>">

--- a/app/webroot/js/comanage.js
+++ b/app/webroot/js/comanage.js
@@ -60,25 +60,7 @@ function setApplicationPreference(tag,value) {
   $.ajax({
     url: apUrl,
     type: 'PUT',
-    data: jsonData,
-    success: function(data) {
-      // console.log("PUT " + tag + ": " + JSON.stringify(jsonData));
-    }
-  });
-}
-
-// Get an application preference and do something with it
-// tag     - name of preference to retrieve (string, required)
-// fn      - named function that will handle the data
-function getApplicationPreference(tag,fn) {
-  var apUrl = "/registry/application_preferences/" + tag;
-  $.ajax({
-    url: apUrl,
-    type: 'GET',
-    success: function(data) {
-      // console.log("GET " + tag + ": " + JSON.stringify(data));
-      fn(data);
-    }
+    data: jsonData
   });
 }
 

--- a/app/webroot/js/comanage.js
+++ b/app/webroot/js/comanage.js
@@ -51,6 +51,37 @@ function generateFlash(text, type) {
   });
 }
 
+// Set an application preference
+// tag     - name of preference to save (string, required)
+// value   - value to save (json in the form of {"value":"something"} or {"value":null} to unset)
+function setApplicationPreference(tag,value) {
+  var apUrl = "/registry/application_preferences/" + tag;
+  var jsonData = value;
+  $.ajax({
+    url: apUrl,
+    type: 'PUT',
+    data: jsonData,
+    success: function(data) {
+      // console.log("PUT " + tag + ": " + JSON.stringify(jsonData));
+    }
+  });
+}
+
+// Get an application preference and do something with it
+// tag     - name of preference to retrieve (string, required)
+// fn      - named function that will handle the data
+function getApplicationPreference(tag,fn) {
+  var apUrl = "/registry/application_preferences/" + tag;
+  $.ajax({
+    url: apUrl,
+    type: 'GET',
+    success: function(data) {
+      // console.log("GET " + tag + ": " + JSON.stringify(data));
+      fn(data);
+    }
+  });
+}
+
 // Generate a loading animation by revealing a persistent hidden div with CSS animation.
 // An element's onclick action will trigger this to appear if it has the class "spin" class on an element.
 // (See View/Elements/javascript.ctp)


### PR DESCRIPTION
Extend Application Preferences for use in all views. This provides a new view variable for accessing a user's application preferences and makes use of them to set the state of the main menu drawer. The legacy use of Cookies for this purpose is deprecated. A JavaScript setter function is added for AJAX PUT of Application Variables.