### PR TITLE
Fix overflow issues within table cells (CO-2174)

### DIFF
--- a/app/View/Addresses/index.ctp
+++ b/app/View/Addresses/index.ctp
@@ -42,7 +42,7 @@
         <!-- XXX Following needs to be I18N'd, and also render a full name, if index view sticks around -->
         <th><?php print $this->Paginator->sort('OrgIdentity.PrimaryName.family', 'Org Identity'); ?></th>
         <th><?php print $this->Paginator->sort('CoPersonRole.PrimaryName.family', 'CO Person Role'); ?></th>
-        <th><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
     

--- a/app/View/CoDashboardWidgets/index.ctp
+++ b/app/View/CoDashboardWidgets/index.ctp
@@ -86,7 +86,7 @@
       <tr>
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
         <th><?php print $this->Paginator->sort('plugin', _txt('fd.plugin')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/CoDashboardWidgets/order.ctp
+++ b/app/View/CoDashboardWidgets/order.ctp
@@ -108,7 +108,7 @@
   <table id="dashboard_widgets">
     <thead>
       <tr>
-        <th><?php print _txt('fd.order'); ?></th>
+        <th class="order"><?php print _txt('fd.order'); ?></th>
         <th><?php print _txt('fd.desc'); ?></th>
         <th><?php print _txt('fd.plugin'); ?></th>
       </tr>

--- a/app/View/CoDepartments/index.ctp
+++ b/app/View/CoDepartments/index.ctp
@@ -58,7 +58,7 @@
       <tr>
         <th><?php print $this->Paginator->sort('name', _txt('fd.name')); ?></th>
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
-        <th><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
 

--- a/app/View/CoEnrollmentAttributes/index.ctp
+++ b/app/View/CoEnrollmentAttributes/index.ctp
@@ -87,7 +87,7 @@
       <tr>
         <th><?php print $this->Paginator->sort('label', _txt('fd.ea.label')); ?></th>
         <th><?php print $this->Paginator->sort('attribute', _txt('fd.attribute')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.ea.order')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.ea.order')); ?></th>
         <th><?php print $this->Paginator->sort('required', _txt('fd.required')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>

--- a/app/View/CoEnrollmentFlowWedges/index.ctp
+++ b/app/View/CoEnrollmentFlowWedges/index.ctp
@@ -88,7 +88,7 @@
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
         <th><?php print $this->Paginator->sort('plugin', _txt('fd.plugin')); ?></th>
         <th><?php print $this->Paginator->sort('status', _txt('fd.status')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/CoEnrollmentSources/index.ctp
+++ b/app/View/CoEnrollmentSources/index.ctp
@@ -88,7 +88,7 @@
   <!-- XXX this is sorting by ID, but rendering by name -->
         <th><?php print $this->Paginator->sort('org_identity_source_id', _txt('ct.org_identity_sources.1')); ?></th>
         <th><?php print $this->Paginator->sort('org_identity_mode', _txt('fd.ef.orgid')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/CoGroups/fields.inc
+++ b/app/View/CoGroups/fields.inc
@@ -259,7 +259,7 @@
       <tr>
         <th><?php print _txt('fd.name'); ?></th>
         <th><?php print _txt('fd.type'); ?></th>
-        <th class="actionButtons"><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
     <tbody>
@@ -362,7 +362,7 @@
             <?php print _txt('fd.co_group.'.$k.'.pl'); ?> -
             <em><?php print _txt('fd.co_group.'.$k.'.desc', array(filter_var($co_groups[0]['CoGroup']['name'],FILTER_SANITIZE_STRING))); ?></em>
           </th>
-          <th class="actionButtons"><?php print _txt('fd.actions'); ?></th>
+          <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
         </tr>
       </thead>
       <tbody>
@@ -422,7 +422,7 @@
         <th><?php print _txt('fd.name'); ?></th>
         <th><?php print _txt('fd.status'); ?></th>
         <th><?php print _txt('fd.type'); ?></th>
-        <th class="actionButtons"><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
     <tbody>
@@ -522,7 +522,7 @@
         <th><?php print _txt('fd.name'); ?></th>
         <th><?php print _txt('fd.co_people.status'); ?></th>
         <th><?php print _txt('fd.roles'); ?></th>
-        <th class="actionButtons"><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
     <tbody>

--- a/app/View/CoIdentifierAssignments/index.ctp
+++ b/app/View/CoIdentifierAssignments/index.ctp
@@ -123,7 +123,7 @@
     <tr>
       <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
       <th><?php print $this->Paginator->sort('identifier_type', _txt('fd.type')); ?></th>
-      <th><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
+      <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
       <th><?php print $this->Paginator->sort('context', _txt('fd.ia.context')); ?></th>
       <th><?php print _txt('fd.actions'); ?></th>
     </tr>

--- a/app/View/CoIdentifierAssignments/order.ctp
+++ b/app/View/CoIdentifierAssignments/order.ctp
@@ -93,7 +93,7 @@
   <table id="provisioning_targets">
     <thead>
       <tr>
-        <th><?php print _txt('fd.order'); ?></th>
+        <th class="order"><?php print _txt('fd.order'); ?></th>
         <th><?php print _txt('fd.desc'); ?></th>
         <th><?php print _txt('fd.type'); ?></th>
       </tr>

--- a/app/View/CoNavigationLinks/index.ctp
+++ b/app/View/CoNavigationLinks/index.ctp
@@ -73,8 +73,7 @@
         <th><?php print $this->Paginator->sort('title', _txt('fd.link.title')); ?></th>
         <th><?php print $this->Paginator->sort('url', _txt('fd.link.url')); ?></th>
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.link.order')); ?></th>
-
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.link.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/CoPeople/index.ctp
+++ b/app/View/CoPeople/index.ctp
@@ -127,7 +127,7 @@ if(!empty($vv_alphabet_search)) {
         <?php /*
         <th class="spin"><?php print $this->Paginator->sort('created', _txt('fd.created')); ?></th>
         <th class="spin"><?php print $this->Paginator->sort('modified', _txt('fd.modified')); ?></th> */ ?>
-        <th class="actionButtons"><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
     <?php foreach ($co_people as $p): ?>

--- a/app/View/CoPipelines/index.ctp
+++ b/app/View/CoPipelines/index.ctp
@@ -58,7 +58,7 @@
       <tr>
         <th><?php print $this->Paginator->sort('name', _txt('fd.key')); ?></th>
         <th><?php print $this->Paginator->sort('status', _txt('fd.status')); ?></th>
-        <th><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
 

--- a/app/View/CoProvisioningTargetFilters/index.ctp
+++ b/app/View/CoProvisioningTargetFilters/index.ctp
@@ -85,7 +85,7 @@
     <thead>
       <tr>
         <th><?php print $this->Paginator->sort('data_filter_id', _txt('ct.data_filters.1')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/CoProvisioningTargetFilters/order.ctp
+++ b/app/View/CoProvisioningTargetFilters/order.ctp
@@ -107,7 +107,7 @@
   <table id="provisioning_targets">
     <thead>
       <tr>
-        <th><?php print _txt('fd.order'); ?></th>
+        <th class="order"><?php print _txt('fd.order'); ?></th>
         <th><?php print _txt('fd.desc'); ?></th>
         <th><?php print _txt('fd.plugin'); ?></th>
       </tr>

--- a/app/View/CoProvisioningTargets/index.ctp
+++ b/app/View/CoProvisioningTargets/index.ctp
@@ -112,7 +112,7 @@
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
         <th><?php print $this->Paginator->sort('plugin', _txt('fd.plugin')); ?></th>
         <th><?php print $this->Paginator->sort('status', _txt('fd.status')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/CoProvisioningTargets/order.ctp
+++ b/app/View/CoProvisioningTargets/order.ctp
@@ -92,7 +92,7 @@
   <table id="provisioning_targets">
     <thead>
       <tr>
-        <th><?php print _txt('fd.order'); ?></th>
+        <th class="order"><?php print _txt('fd.order'); ?></th>
         <th><?php print _txt('fd.desc'); ?></th>
         <th><?php print _txt('fd.plugin'); ?></th>
       </tr>

--- a/app/View/CoTermsAndConditions/index.ctp
+++ b/app/View/CoTermsAndConditions/index.ctp
@@ -74,7 +74,7 @@
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
         <th><?php print $this->Paginator->sort('status', _txt('fd.status')); ?></th>
         <th><?php print $this->Paginator->sort('cou', _txt('fd.cou')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.tc.order')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.tc.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/CoTermsAndConditions/order.ctp
+++ b/app/View/CoTermsAndConditions/order.ctp
@@ -92,7 +92,7 @@ print $this->element("pageTitleAndButtons", $params);
   <table id="terms_and_conditions">
     <thead>
     <tr>
-      <th><?php print _txt('fd.order'); ?></th>
+      <th class="order"><?php print _txt('fd.order'); ?></th>
       <th><?php print _txt('fd.desc'); ?></th>
     </tr>
     </thead>

--- a/app/View/DictionaryEntries/index.ctp
+++ b/app/View/DictionaryEntries/index.ctp
@@ -94,7 +94,7 @@
       <tr>
         <th><?php print $this->Paginator->sort('value', _txt('fd.value')); ?></th>
         <th><?php print $this->Paginator->sort('code', _txt('fd.code')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.ordr')); ?></th>
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.ordr')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/NavigationLinks/index.ctp
+++ b/app/View/NavigationLinks/index.ctp
@@ -71,8 +71,7 @@
         <th><?php print $this->Paginator->sort('title', _txt('fd.link.title')); ?></th>
         <th><?php print $this->Paginator->sort('url', _txt('fd.link.url')); ?></th>
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
-        <th><?php print $this->Paginator->sort('ordr', _txt('fd.link.order')); ?></th>
-
+        <th class="order"><?php print $this->Paginator->sort('ordr', _txt('fd.link.order')); ?></th>
         <th><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>

--- a/app/View/OrgIdentities/index.ctp
+++ b/app/View/OrgIdentities/index.ctp
@@ -93,7 +93,7 @@ if(!empty($vv_alphabet_search)) {
       <th><?php print $this->Paginator->sort('ou', _txt('fd.ou')); ?></th>
       <th><?php print $this->Paginator->sort('title', _txt('fd.title')); ?></th>
       <th><?php print $this->Paginator->sort('affiliation', _txt('fd.affiliation')); ?></th>
-      <th class="actionButtons"><?php print _txt('fd.actions'); ?></th>
+      <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
     </tr>
     </thead>
 

--- a/app/View/Organizations/index.ctp
+++ b/app/View/Organizations/index.ctp
@@ -58,7 +58,7 @@
       <tr>
         <th><?php print $this->Paginator->sort('name', _txt('fd.name')); ?></th>
         <th><?php print $this->Paginator->sort('description', _txt('fd.desc')); ?></th>
-        <th><?php print _txt('fd.actions'); ?></th>
+        <th class="thinActionButtonsCol"><?php print _txt('fd.actions'); ?></th>
       </tr>
     </thead>
 

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -2261,8 +2261,11 @@ th a:hover,
   color: #ff3;
   text-decoration: none !important;
 }
-th.actionButtons {
+th.thinActionButtonsCol {
   width: 180px;
+}
+th.order {
+  width: 80px;
 }
 tr td:first-child {
   padding-left: 1em;

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -1241,9 +1241,10 @@ body.co_petitions .ui-dialog {
 #co-people-index .actions {
   padding: 0.5em 1em 1em;
 }
-/* PEOPLE LISTING - ACCORDIANS (legacy) */
+/* PEOPLE LISTING - CO PETITIONS and ACCORDIANS (legacy) */
 #co_people {
   clear: both;
+  table-layout: auto; /* override fixed table layout */
 }
 #co_people > .co-person {
   margin: 0;
@@ -2226,6 +2227,7 @@ table {
   border-collapse: collapse;
   border-left: 1px solid #eee;
   border-right: 1px solid #eee;
+  table-layout: fixed;
 }
 .table-container {
   overflow: auto;
@@ -2240,6 +2242,9 @@ th, td {
   border-right: 2px solid #fff;
   border-bottom: 2px solid #fff;
   font-weight: normal;
+}
+td {
+  overflow-wrap: break-word;
 }
 table.common-table td {
   padding: 0.25em 0.25em 0.25em 0.5em;
@@ -2256,6 +2261,9 @@ th a:hover,
   color: #ff3;
   text-decoration: none !important;
 }
+th.actionButtons {
+  width: 180px;
+}
 tr td:first-child {
   padding-left: 1em;
 }
@@ -2265,9 +2273,6 @@ tr td:last-child {
 }
 tr.noborder td {
   border: none;
-}
-th.actionButtons {
-  width:70px;
 }
 /* legacy zebra stripes for rows;
    0 used for autoincrementing line counters;


### PR DESCRIPTION
The primary change introduced by this PR is to give tables a fixed table-layout by default. This does two things: it allows us to set the overflow-wrap of table cells to default "break-word" - solving the problem described in CO-2174, and it will allow tables to render more quickly in browsers.

Two classes were introduced to narrow the order column and a few of the action buttons columns when doing so was worthwhile, but tables do not require them.