### PR TITLE
CO-2180_Localizations_can_not_be_used_by_Shell_Jobs

### DIFF
--- a/app/Console/Command/JobShell.php
+++ b/app/Console/Command/JobShell.php
@@ -28,6 +28,7 @@
 class JobShell extends AppShell {
   var $uses = array('Co',
                     'CoJob',
+                    'CoLocalization',
                     'CmpEnrollmentConfiguration',
                     'Lock');
   
@@ -250,7 +251,10 @@ class JobShell extends AppShell {
       }
       
       $this->out(_txt('sh.job.lock.obt', array($lockid)), 1, Shell::NORMAL);
-      
+
+      // Load localizations
+      $this->CoLocalization->load($this->params['coid']);
+
       // Pull all jobs where status is queued and whose start time isn't deferred.
       // We do this in a loop rather than pull all at once for two reasons:
       // (1) to work with very large queues (this is effectively keyset pagination

--- a/app/Model/CoLocalization.php
+++ b/app/Model/CoLocalization.php
@@ -64,4 +64,46 @@ class CoLocalization extends AppModel {
       'allowEmpty' => false
     )
   );
+
+  /**
+   * Load language localizations
+   *
+   * @param int $coid CO Id
+   */
+  public function load($coid) {
+    // Load dynamic texts. We do this here because lang.php doesn't have access to models yet.
+    global $cm_lang, $cm_texts;
+
+    $args = array();
+    $args['joins'][0]['table'] = 'cos';
+    $args['joins'][0]['alias'] = 'Co';
+    $args['joins'][0]['type'] = 'INNER';
+    $args['joins'][0]['conditions'][0] = 'CoLocalization.co_id=Co.id';
+    $args['conditions']['Co.name'] = DEF_COMANAGE_CO_NAME;
+    $args['conditions']['Co.status'] = StatusEnum::Active;
+    $args['conditions']['CoLocalization.language'] = $cm_lang;
+    $args['fields'] = array('CoLocalization.lkey', 'CoLocalization.text');
+    $args['contain'] = false;
+
+    $ls_cm = $this->find('list', $args);
+    unset($args);
+
+    // First load the Platform localization variables
+    if(!empty($ls_cm)) {
+      $cm_texts[$cm_lang] = array_merge($cm_texts[$cm_lang], $ls_cm);
+    }
+
+    $args = array();
+    $args['conditions']['CoLocalization.co_id'] = $coid;
+    $args['conditions']['CoLocalization.language'] = $cm_lang;
+    $args['fields'] = array('CoLocalization.lkey', 'CoLocalization.text');
+    $args['contain'] = false;
+
+    $ls_co = $this->find('list', $args);
+
+    // Replace all default texts with the ones configured in CO level
+    if(!empty($ls_co)) {
+      $cm_texts[$cm_lang] = array_merge($cm_texts[$cm_lang], $ls_co);
+    }
+  }
 }


### PR DESCRIPTION
- Move localization loading into CoLocalization Model.
- Jobshell loads localization's