### PR TITLE
CO-2264_CO_Admins_cannot_create_Departments_until_a_CMP_creates_at_least_one

### DIFF
--- a/app/Controller/AppController.php
+++ b/app/Controller/AppController.php
@@ -1072,9 +1072,10 @@ class AppController extends Controller {
     $p['menu']['coconfig'] = $roles['cmadmin'] || $roles['coadmin'];
     
     // View CO departments?
-    $p['menu']['codepartments'] = $roles['cmadmin'];
+    $p['menu']['codepartments'] = $roles['cmadmin'] || $roles['coadmin'];;
     
     if(!$roles['cmadmin']
+       && !$roles['coadmin']
        && $roles['user']
        && !empty($this->cur_co['Co']['id'])) {
       // Only render departments link for regular users if departments are defined


### PR DESCRIPTION
Allow CO Admins to create Departments on a vanilla COmanage environment