### PR TITLE
CO-1904_First_field_does_not_have_input_focus_when_manually_adding_new_CO_person_role

### DIFF
--- a/app/View/CoPersonRoles/fields.inc
+++ b/app/View/CoPersonRoles/fields.inc
@@ -156,7 +156,7 @@
         'CoPersonRole.title'
       )
     );
-    print $this->element('enumerations', $args); 
+    print $this->element('enumerations', $args);
   ?>
 
   <div id="<?php print $this->action; ?>_role_attributes" class="explorerContainer">
@@ -209,6 +209,7 @@
                       ? $co_person_roles[0]['CoPersonRole']['cou_id']
                       : 0);
                     $attrs['empty'] = $vv_allow_empty_cou;
+                    $attrs['autofocus'] = true;
 
                     if($e && !$es) {
                       print $this->Form->select('cou_id',
@@ -246,6 +247,7 @@
                     ? $co_person_roles[0]['CoPersonRole']['affiliation']
                     : AffiliationEnum::Member);
                   $attrs['empty'] = false;
+                  $attrs['autofocus'] = empty($vv_available_cous);
 
                   if($e && !$es) {
                     print $this->Form->select('affiliation',


### PR DESCRIPTION
Enable autofocus for the first field of CoPersonRole add/view form