### PR TITLE
Change closeWith option for Noty.js dialogs from "click" to "button" …

### DIFF
--- a/app/webroot/js/comanage.js
+++ b/app/webroot/js/comanage.js
@@ -47,6 +47,7 @@ function generateFlash(text, type) {
     type: type,
     dismissQueue: true,
     layout: 'topCenter',
+    closeWith: ['button'],
     theme: 'comanage'
   });
 }


### PR DESCRIPTION
…allowing Noty messages to be copied. (CO-2334)

This is a one-line change that fixes this problem directly. 