### PR TITLE
CO-2339_ApiUser_View_missing_action_view_proper_render_for_the_field_priviledged

### DIFF
--- a/app/View/ApiUsers/fields.inc
+++ b/app/View/ApiUsers/fields.inc
@@ -247,7 +247,8 @@
       <div class="field-desc"><?php print _txt('fd.api.priv.desc'); ?></div>
     </div>
     <div class="field-info">
-      <?php print $this->Form->input('privileged'); ?>
+      <?php print $e ? $this->Form->input('privileged')
+                     : ($api_users[0]['ApiUser']['privileged'] ? _txt('fd.true') : _txt('fd.false')); ?>
     </div>
   </li>
   <?php else: // co > 1 ?>


### PR DESCRIPTION
Do not render input field when the action is view