### PR TITLE
CO-2353_REST_users_cannot_create_UnixCluster

### DIFF
--- a/app/AvailablePlugin/UnixCluster/Model/UnixCluster.php
+++ b/app/AvailablePlugin/UnixCluster/Model/UnixCluster.php
@@ -31,6 +31,9 @@ class UnixCluster extends ClusterInterface {
   // Define class name for cake
   public $name = "UnixCluster";
 
+  // Current schema version for API
+  public $version = "1.0";
+
   // Required by COmanage Plugins
   public $cmPluginType = "cluster";
 	


### PR DESCRIPTION
Fix UnixCluster version and add permissions for priviledged REST API users