### PR TITLE
CO-2177_REST_API_Should_Support_Filtering_MVPAs_By_CO_ID

### DIFF
--- a/app/Controller/Component/ApiComponent.php
+++ b/app/Controller/Component/ApiComponent.php
@@ -345,9 +345,7 @@ class ApiComponent extends Component {
       
       switch($this->request->params['ext']) {
         case 'json':
-          $fh = fopen('php://input', 'r');
-          $doc = stream_get_contents($fh);
-          fclose($fh);
+          $doc = file_get_contents("php://input");
           if(!empty($doc)) {
             $json = json_decode($doc, true);
             
@@ -361,9 +359,7 @@ class ApiComponent extends Component {
           }
           break;
         case 'xml':
-          $fh = fopen('php://input', 'r');
-          $doc = stream_get_contents($fh);
-          fclose($fh);
+          $doc = file_get_contents("php://input");
           if(!empty($doc)) {
             $xml = Xml::toArray(Xml::build($doc));
             $this->reqData = $xml[$this->reqModelNamePl][$this->reqModelName];
@@ -390,10 +386,8 @@ class ApiComponent extends Component {
    * @param  $data    Parsed PUT/POST body
    * @return int      CO ID, or null if not found
    */
-  
+
   public function requestedCOID($model, $request, $data) {
-    $coid = null;
-    
     // As of Registry v3.3.0, CO level API users are allowed to assert a CO ID
     // for REST operations that meet the following requirements:
     //
@@ -401,7 +395,7 @@ class ApiComponent extends Component {
     // (2) The requested model directly belongsTo the parent link
     // (Note Registry v5 implements this as a per-model check instead, but
     // we don't have the infrastructure for that.)
-    
+
     if(empty($request->params['pass'])) {
       // For historical reasons, the query string keys aren't standard
       $permittedKeys = array(
@@ -428,67 +422,70 @@ class ApiComponent extends Component {
           'organization_id' => 'Organization'
         )
       );
-      
+
       // PUT and POST are basically the same
       $permittedKeys['PUT'] = $permittedKeys['POST'];
-      
+
       if(!empty($model->permittedApiFilters)) {
         // Merge in the plugin's additional permitted key
         foreach(array('GET', 'POST', 'PUT') as $a) {
           $permittedKeys[$a] = array_merge($permittedKeys[$a], $model->permittedApiFilters);
         }
       }
-      
+
       if(!empty($permittedKeys[$request->method()])) {
         foreach($permittedKeys[$request->method()] as $k => $m) {
           // For plugins, $m is of the form Plugin.Model, but belongsTo[]
           // will be keyed only on Model
           $b = strstr($m, '.');
-          
+
           if($b) {
             $b = ltrim($b, '.');
           } else {
             $b = $m;
           }
-          
+
           if(!empty($model->belongsTo[$b])) {
             if($request->method() == 'GET') {
               if(!empty($request->query[$k])) {
                 if($k == 'coid') {
-                  $coid = $request->query['coid'];
+                  return $request->query['coid'];
                 } else {
                   // For any other key, we need to map it to a CO
-                  
                   $ParentModel = ClassRegistry::init($m);
-                  
-                  $coid = $ParentModel->findCoForRecord($request->query[$k]);
+                  return $ParentModel->findCoForRecord($request->query[$k]);
                 }
-                
-                break;
               }
             } else {
               if(!empty($data[$k])) {
                 if($k == 'co_id') {
-                  $coid = $data['co_id'];
+                  return $data['co_id'];
                 } else {
                   // For any other key, we need to map it to a CO
-                  
                   $ParentModel = ClassRegistry::init($m);
-                  
-                  $coid = $ParentModel->findCoForRecord($data[$k]);
+                  return $ParentModel->findCoForRecord($data[$k]);
                 }
-                
-                break;
               }
             }
           }
         }
+        // Since i am here no direct CO relation found. Get the parents and retry
+        $mparents = $model->belongsTo ?: array();
+        foreach ($mparents as $mname => $mproperties) {
+          // Load the model before performing any more logic
+          $model = ClassRegistry::init($mname);
+          // Get up the tree until we find if we can associate the key with the model
+          $coid = $this->requestedCOID($model, $request, $data);
+          if(!is_null($coid)) {
+            return $coid;
+          }
+        }
       }
     }
-    
-    return $coid;
+
+    return null;
   }
-  
+
   /**
    * Prepare a REST result HTTP header.
    * - precondition: HTTP headers must not yet have been sent


### PR DESCRIPTION
- prefer file_get_contents for php://input content reading
- allow ApiComponent::requestedCOID to search Model relation tree to find if co association exists