### PR TITLE
CO-2377_CO_Petition_Search_Block_breaks_after_delete_redirect

### DIFF
--- a/app/Controller/CoPetitionsController.php
+++ b/app/Controller/CoPetitionsController.php
@@ -2758,9 +2758,7 @@ class CoPetitionsController extends StandardController {
         'co'            => $this->cur_co['Co']['id'],
         'sort'          => 'created',
         'direction'     => 'desc',
-        'search.status' => array(
-          StatusEnum::PendingApproval
-        )
+        'search.status' => StatusEnum::PendingApproval
       ));
     } else {
       $coPersonId = $this->Session->read('Auth.User.co_person_id');


### PR DESCRIPTION
Redirect to the proper search status after deleting a petition