### PR TITLE
Include label for Role and OrgID ID output on Person Canvas (CO-2378)

### DIFF
--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1575,6 +1575,7 @@ original notification at
   'fd.ia.type.email.desc' => 'For Identifier Assignments applied to Type <i>Mail</i>, an Email Address (instead of an Identifier) will be created with this type (if not blank)',
   // fd.id.seq should be used only for database internal column IDs
   'fd.id.seq' =>      'ID',
+  'fd.id.val' =>      'ID: %1$s',
   // The next set must be named fd.model.validation-field
   'fd.identifier.description' => 'Description',
   'fd.identifier.identifier' => 'Identifier',

--- a/app/View/CoPeople/fields.inc
+++ b/app/View/CoPeople/fields.inc
@@ -1076,7 +1076,7 @@
                     'aria-expanded' => false,
                   );
                   print $this->Html->link(
-                    $cou_name . ' <cite class="text-muted-cmg">(' . $r['id'] . ')</cite>',
+                    $cou_name . ' <cite class="text-muted-cmg cm-id-display">' . _txt('fd.id.val', array($r['id'])) . '</cite>',
                     '#collapse_link_' . md5("CoPersonRole" . $r['id']),
                     $linkparams
                   );
@@ -1296,7 +1296,7 @@
                 );
                 // Name
                 print $this->Html->link(
-                  $orgid_name . ' <cite class="text-muted-cmg">(' .filter_var($link['OrgIdentity']['id'],FILTER_SANITIZE_SPECIAL_CHARS) . ')</cite>',
+                  $orgid_name . ' <cite class="text-muted-cmg cm-id-display">' . _txt('fd.id.val', array(filter_var($link['OrgIdentity']['id'],FILTER_SANITIZE_SPECIAL_CHARS))) . '</cite>',
                   '#collapse_link_' . md5("OrgIdentity" . $link['OrgIdentity']['id']),
                   $linkparams
                 );

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -2591,6 +2591,10 @@ td.indented {
 .text-muted-cmg {
   color: #555 !important;
 }
+.cm-id-display {
+  margin-left: 1em;
+  font-size: 0.9em;
+}
 .smaller {
   font-size: smaller;
 }


### PR DESCRIPTION
This PR changes the ID output on Role and OrgID to look like this:
![image](https://user-images.githubusercontent.com/2641891/156806655-1f267879-e8cc-46fc-929d-e76fe5da4d38.png)
