### PR TITLE
CO-2385_Return_404_instead_of_500_when_viewing_unknown_CO_via_API

### DIFF
--- a/app/Model/Co.php
+++ b/app/Model/Co.php
@@ -166,7 +166,13 @@ class Co extends AppModel {
   public function readOnly($id) {
     // A CO is read only if the status field is 'TR'.
 
-    return (bool)$this->inTrash($id);
+    // Refer to CO-2385
+    try{
+      return (bool)$this->inTrash($id);
+    } catch (InvalidArgumentException $e) {
+      return false;
+    }
+
   }
 
   /**


### PR DESCRIPTION
readonly check has to always return boolean