### PR TITLE
CO-2337_Unlinking_organizational_identity_should_remain_on_CO_Person_page

### DIFF
--- a/app/Controller/CoOrgIdentityLinksController.php
+++ b/app/Controller/CoOrgIdentityLinksController.php
@@ -267,6 +267,15 @@ class CoOrgIdentityLinksController extends StandardController {
                             'action' => 'canvas',
                             $this->request->data['CoOrgIdentityLink']['co_person_id']));
     } else {
+      if(isset($this->CoOrgIdentityLink->id)
+         && $this->CoOrgIdentityLink->field('deleted')) {
+        // We just unlinked the OrgIdentity from the CO Person. Get us back canvas
+        $this->redirect(array('controller' => 'co_people',
+                          'action' => 'canvas',
+                          $this->CoOrgIdentityLink->field('co_person_id')));
+      }
+
+      // Fallback. If all the rest fail, redirect to MyPopulation
       $this->redirect(array('controller' => 'co_people',
                             'action' => 'index',
                             'co' => filter_var($this->cur_co['Co']['id'],FILTER_SANITIZE_SPECIAL_CHARS)));


### PR DESCRIPTION
Redirect to CO Person Canvas after unlinking an OrgIdentity