### PR TITLE
Remove link to "Manage Groups" from "select for member" group view (CO-2397)

### DIFF
--- a/app/View/CoGroups/index.ctp
+++ b/app/View/CoGroups/index.ctp
@@ -40,20 +40,6 @@
     $params = array();
     $params['title'] = _txt('op.gr.memadd', array($name_for_title));
 
-    // Add top links
-    $params['topLinks'] = array();
-    $params['topLinks'][] = $this->Html->link(
-      _txt('op.grm.manage.all'),
-      array(
-        'controller' => 'co_groups',
-        'action' => 'index',
-        'copersonid' => $this->Session->read('Auth.User.co_person_id'),
-        'co' => $cur_co['Co']['id'],
-        'search.auto' => 'f',
-        'search.noadmin' => '1'
-      ),
-      array('class' => 'runbutton')
-    );
   } else {
     // Add breadcrumbs
     $this->Html->addCrumb(_txt('ct.co_groups.pl'));


### PR DESCRIPTION
The link has limited value in this view, and this is the simplest solution to avoid context confusion that this link creates. 