### PR TITLE
Fix theme setting for "Hide Title" to be "Hide Title Banner" (CO-2414)

### DIFF
--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1889,7 +1889,7 @@ original notification at
   'fd.th.css' =>      'CSS',
   'fd.th.footer' =>   'Footer',
   'fd.th.header' =>   'Header',
-  'fd.th.hide_title' => 'Hide Title',
+  'fd.th.hide_title' => 'Hide Title Banner',
   'fd.th.hide_footer_logo' => 'Hide Footer Logo',
   'fd.theme' =>       'Theme',
   'fd.theme.stacking_status' => 'Inheritance/Stacking',

--- a/app/View/Layouts/default.ctp
+++ b/app/View/Layouts/default.ctp
@@ -171,10 +171,9 @@
           <?php print $this->element('menuUser'); ?>
         </nav>
       </div>
-
-      <header id="banner">
-
-        <?php if(!isset($vv_theme_hide_title) || !$vv_theme_hide_title): ?>
+  
+      <?php if(!isset($vv_theme_hide_title) || !$vv_theme_hide_title): ?>
+        <header id="banner">
           <div id="collaborationTitle">
             <?php
               if(!empty($cur_co['Co']['name'])) {
@@ -189,32 +188,31 @@
               }
             ?>
           </div>
-        <?php endif; // $vv_theme_hide_title ?>
 
-        <div id="logo">
-          <?php
-            $imgFile = 'COmanage-Logo-LG-onBlue.png';
-
-            if(is_readable(APP . WEBROOT_DIR . DS . 'img' . DS . 'logo.png')) {
-              // A custom logo has been installed, so use that instead
-              $imgFile = 'logo.png';
-            }
-
-            // Clicking on the logo will take us to the front page
-            print $this->Html->link(
-              $this->Html->image(
-                $imgFile,
-                array(
-                  'alt' => 'COmanage Logo'
-                )
-              ),'/',
-              array('escape' => false)
-            );
-          ?>
-        </div>
-
-      </header>
-
+          <div id="logo">
+            <?php
+              $imgFile = 'COmanage-Logo-LG-onBlue.png';
+  
+              if(is_readable(APP . WEBROOT_DIR . DS . 'img' . DS . 'logo.png')) {
+                // A custom logo has been installed, so use that instead
+                $imgFile = 'logo.png';
+              }
+  
+              // Clicking on the logo will take us to the front page
+              print $this->Html->link(
+                $this->Html->image(
+                  $imgFile,
+                  array(
+                    'alt' => 'COmanage Logo'
+                  )
+                ),'/',
+                array('escape' => false)
+              );
+            ?>
+          </div>
+        </header>
+      <?php endif; // $vv_theme_hide_title ?>
+      
       <div id="main-wrapper">
         <?php if($vv_ui_mode === EnrollmentFlowUIMode::Full): ?>
           <?php

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -475,6 +475,10 @@ form#notificationStatus {
 .material-icons.error {
   color: #d00;
 }
+/* MAIN WRAPPER */
+#main-wrapper {
+  clear: both;
+}
 /* NAVIGATION / SIDE DRAWER */
 #navigation {
   z-index: 100;


### PR DESCRIPTION
This ensures the entire title banner (with CO Title and COmanage Logo) are hidden when the "Hide Title Banner" checkbox is checked in theme settings.