### PR TITLE
Add CO Person Role: improve COU select field (CO-2392)

### DIFF
--- a/app/View/CoPersonRoles/fields.inc
+++ b/app/View/CoPersonRoles/fields.inc
@@ -208,7 +208,10 @@
                     $attrs['value'] = (isset($co_person_roles[0]['CoPersonRole']['cou_id'])
                       ? $co_person_roles[0]['CoPersonRole']['cou_id']
                       : 0);
-                    $attrs['empty'] = $vv_allow_empty_cou;
+                    $attrs['empty'] = '';
+                    if(!$vv_allow_empty_cou) {
+                      $attrs['required'] = 'required';
+                    }
                     $attrs['autofocus'] = true;
 
                     if($e && !$es) {


### PR DESCRIPTION
Require selection of COU when "Allow Empty COUs" is not enabled, and make intial state of COU field blank.