### PR TITLE
Fix default pattern selection in CoIdentifierAssignements (CO-2391)

### DIFF
--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -1544,7 +1544,7 @@ original notification at
   'fd.ia.format' =>   'Format',
   'fd.ia.format.desc' => 'See <a href="https://spaces.at.internet2.edu/display/COmanage/Configuring+Registry+Identifier+Assignment">Configuring Registry Identifier Assignment</a> for details',
   'fd.ia.format.prefab' => 'Select a Common Pattern',
-  'fd.ia.format.pattern' => 'Pattern',
+  'fd.ia.format.pattern' => 'Common patterns',
   'fd.ia.format.p0' => 'Default (#)',
   'fd.ia.format.p1' => 'given.family(.#)@myvo.org',
   'fd.ia.format.p2' => 'given(.m).family(.#)@myvo.org',

--- a/app/View/CoIdentifierAssignments/fields.inc
+++ b/app/View/CoIdentifierAssignments/fields.inc
@@ -281,14 +281,13 @@
       <div class="field-desc"><?php print _txt('fd.ia.format.desc'); ?></div>
     </div>
     <div class="field-info">
-      <?php print ($e ? $this->Form->input('format') : filter_var($co_identifier_assignments[0]['CoIdentifierAssignment']['format'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
+      <?php print ($e ? $this->Form->input('format',array('default'=>'(#)')) : filter_var($co_identifier_assignments[0]['CoIdentifierAssignment']['format'],FILTER_SANITIZE_SPECIAL_CHARS)); ?>
       <?php if($e): ?>
         <label for="CoIdentifierAssignmentPrefabricatedFormats"><?php print  _txt('fd.ia.format.pattern') . ': '; ?></label>
         <select
           id="CoIdentifierAssignmentPrefabricatedFormats"
           onchange="javascript:document.getElementById('CoIdentifierAssignmentFormat').value=this.value">
-          <option value=""><?php print _txt('fd.ia.format.prefab'); ?></option>
-          <option value=""><?php print _txt('fd.ia.format.p0'); ?></option>
+          <option value="(#)"><?php print _txt('fd.ia.format.p0'); ?></option>
           <option value="(g).(f)[1:.(#)]@myvo.org"><?php print _txt('fd.ia.format.p1'); ?></option>
           <option value="(g)[1:.(m:1)].(f)[2:.(#)]@myvo.org"><?php print _txt('fd.ia.format.p2'); ?></option>
           <option value="(g:1)(m:1)(f:1)(#)@myvo.org"><?php print _txt('fd.ia.format.p3'); ?></option>


### PR DESCRIPTION
This PR sets the default format value to "(#)", ensures that selecting the default in the drop-down sets the field, and removes the empty option. 

![image](https://user-images.githubusercontent.com/2641891/167688477-8a885804-2a23-492d-b871-198e2e258977.png)
