### PR TITLE
Restore table-layout to default behavior and fix problem view from original CO-2174 ticket (CO-2398)

### DIFF
--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -2194,6 +2194,7 @@ original notification at
   'op.mt.test.wait' => 'Sending...',
   'op.next' =>        'Next',
   'op.ois.conf.gr' => 'Configure Group Mapping',
+  'op.ois.toggle.format' => 'Toggle formatting',
   'op.ois.inventory' => 'View %1$s Inventory',
   'op.ok' =>          'OK',
   'op.order-a' =>     'Reorder %1$s',

--- a/app/View/OrgIdentitySources/retrieve.ctp
+++ b/app/View/OrgIdentitySources/retrieve.ctp
@@ -159,6 +159,15 @@
 </div>
 <br />
 <?php else: // vv_not_found ?>
+<script>
+  $(function() {
+    // Toggle source record formatting
+    $("#source-record-format-toggle").click(function (e) {
+      e.preventDefault();
+      $("code.source-record").toggleClass("source-record-formatted");
+    });
+  });
+</script>
 <div class="innerContent">
   <div class="table-container">
     <table id="view_org_identity_source_record">
@@ -404,13 +413,16 @@
             <span class="descr"><?php print _txt('fd.ois.record.desc'); ?></span>
           </td>
           <td>
-            <pre>
+            <button id="source-record-format-toggle" class="btn btn-link">
+              <?php print _txt('op.ois.toggle.format') ?>
+            </button>
+            <code class="source-record">
               <?php
                 if(!empty($vv_raw_source_record)) {
                 print filter_var($vv_raw_source_record,FILTER_SANITIZE_SPECIAL_CHARS);
                 }
               ?>
-            </pre>
+            </code>
           </td>
         </tr>
         <?php if($vv_org_identity_source['hash_source_record']): ?>

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -1315,7 +1315,6 @@ body.co_petitions .ui-dialog {
 /* PEOPLE LISTING - CO PETITIONS and ACCORDIANS (legacy) */
 #co_people {
   clear: both;
-  table-layout: auto; /* override fixed table layout */
 }
 #co_people > .co-person {
   margin: 0;
@@ -2317,7 +2316,17 @@ a.desc::before {
 }
 code,
 .fixed-width * {
-  font-family: "Courier New","Courier",monospace !important;
+  font-family: "Courier New", "Courier", monospace;
+  color: var(--cmg-color-black-001);
+  font-size: 0.9em;
+  text-align: left;
+}
+code.source-record-formatted {
+  white-space: pre;
+}
+#source-record-format-toggle {
+  float: right;
+  margin-bottom: 1em;
 }
 /*Bootstrap badge*/
 .badge {
@@ -2381,10 +2390,9 @@ table {
   border-collapse: collapse;
   border-left: 1px solid #eee;
   border-right: 1px solid #eee;
-  table-layout: fixed;
 }
-table.cake-sql-log {
-  table-layout: auto;
+table.fixed-table {
+  table-layout: fixed;
 }
 .table-container {
   overflow: auto;
@@ -2582,6 +2590,12 @@ td.indented {
 .btn-secondary {
   background-color: #c33; /* red */
   color: var(--cmg-color-white);
+}
+.btn-link {
+  text-transform: unset;
+  color: var(--cmg-color-blue-primary);
+  padding: 0;
+  font-size: 1em;
 }
 /*Bootstrap*/
 .dropdown-menu {


### PR DESCRIPTION
This PR removes the global use of "table-layout: fixed" instead allowing tables to behave using default behavior. It also corrects the problem found in CO-2174 that led to the original change.

As part of this ticket, the "pre" tag has been removed from the view of org identity source records, and a toggle has been put in place to allow users to apply "white-space: pre" to the source record field via that toggle.

<img width="1233" alt="image" src="https://user-images.githubusercontent.com/2641891/167709625-692f072e-5528-415c-92b1-da65f8498cec.png">
