### PR TITLE
Fix calls to jQuery show() in new enrollment attributes form (CO-2462)

### DIFF
--- a/app/View/CoEnrollmentAttributes/fields.inc
+++ b/app/View/CoEnrollmentAttributes/fields.inc
@@ -115,7 +115,7 @@
     var attrtype = curattr[0];
     
     if(attrtype == "r" || attrtype == "o" || attrtype == "x" || attrtype == "g") {
-      $("#attr_def_div").show("fade", { "direction" : "up" });
+      $("#attr_def_div").show("fade");
       
       // Adjust the gadgets shown
       
@@ -200,7 +200,7 @@
         $("#attr_def_val_div").show("fade");
       }
     } else {
-      $("#attr_def_div").hide("fade", { "direction" : "up" });
+      $("#attr_def_div").hide("fade");
     }
   }
   


### PR DESCRIPTION
The call to show() with an options object required easing to be specified. There was negligible perceptual difference between adding easing or removing the object, so the simpler was chosen: the options object was removed. 

(This appears to be the only place in the code where the options object was used in a show() function.)