### PR TITLE
CO-2495_REST_API_v1_CoGroupMember_response_does_not_contain_group_id

### DIFF
--- a/app/View/Standard/json/view.ctp
+++ b/app/View/Standard/json/view.ctp
@@ -56,10 +56,6 @@
               $a['Person'] = array('Type' => 'Dept',
                                    'Id' => $m[$req][$k]);
               break;
-            case 'CoGroupId':
-              $a['Person'] = array('Type' => 'Group',
-                                   'Id' => $m[$req][$k]);
-              break;
             case 'CoPersonId':
               $a['Person'] = array('Type' => 'CO',
                                    'Id' => $m[$req][$k]);


### PR DESCRIPTION
Include CoGroupId in CoGroupMember GET response