### PR TITLE
CO-2484_Elector_Data_Filter_imrovements

### DIFF
--- a/app/AvailablePlugin/ElectorDataFilter/Config/Schema/schema.xml
+++ b/app/AvailablePlugin/ElectorDataFilter/Config/Schema/schema.xml
@@ -40,9 +40,9 @@
         <field name="attribute_name" type="C" size="32" />
         <field name="outbound_attribute_type" type="C" size="32" />
         <!--    oldest/newest    -->
-        <field name="tie_break_mode" type="C" size="1" />
+        <field name="tie_break_mode" type="C" size="2" />
         <!--   insert/replace     -->
-        <field name="replacement_mode" type="C" size="1" />
+        <field name="replacement_mode" type="C" size="2" />
         <field name="created" type="T" />
         <field name="modified" type="T" />
         <field name="elector_data_filter_id" type="I">

--- a/app/AvailablePlugin/ElectorDataFilter/Controller/ElectorDataFiltersController.php
+++ b/app/AvailablePlugin/ElectorDataFilter/Controller/ElectorDataFiltersController.php
@@ -77,12 +77,14 @@ class ElectorDataFiltersController extends StandardController {
       foreach ($available_types as $type) {
         $attribute_types[$m][$type] = $type;
       }
+      natsort($attribute_types[$m]);
     }
-
-    $this->set('vv_attribute_names', array_combine(
+    $attribute_names = array_combine(
       $this->ElectorDataFilter->validate["attribute_name"]["content"]["rule"][1],
       $this->ElectorDataFilter->validate["attribute_name"]["content"]["rule"][1]
-    ));
+    );
+    natsort($attribute_names);
+    $this->set('vv_attribute_names', $attribute_names);
     $this->set('vv_attribute_types', $attribute_types);
     parent::beforeRender();
   }
@@ -126,11 +128,13 @@ class ElectorDataFiltersController extends StandardController {
    */
 
   public function performRedirect() {
+    $modelName = $pluginName = Inflector::singularize($this->name);
+
     $target = array();
-    $target['plugin'] = null;
-    $target['controller'] = "data_filters";
-    $target['action'] = 'index';
-    $target['co'] = $this->cur_co['Co']['id'];
+    $target['plugin'] = Inflector::underscore($pluginName);
+    $target['controller'] = Inflector::tableize($modelName);
+    $target['action'] = 'edit';
+    $target[] = $this->request->data['ElectorDataFilter']['id'];
 
     $this->redirect($target);
   }

--- a/app/AvailablePlugin/ElectorDataFilter/Lib/enum.php
+++ b/app/AvailablePlugin/ElectorDataFilter/Lib/enum.php
@@ -1,12 +1,12 @@
 <?php
 
 class ReplacementModeEnum {
-  const Insert     = 'I';
-  const Replace    = 'R';
+  const Insert     = 'IN';
+  const Replace    = 'RL';
 }
 
 
 class TieBreakReplacementModeEnum {
-  const Oldest     = 'O';
-  const Newest     = 'N';
+  const Oldest     = 'OL';
+  const Newest     = 'NW';
 }

--- a/app/AvailablePlugin/ElectorDataFilter/Model/ElectorDataFilter.php
+++ b/app/AvailablePlugin/ElectorDataFilter/Model/ElectorDataFilter.php
@@ -41,7 +41,7 @@ class ElectorDataFilter extends AppModel
   public $belongsTo = array("DataFilter");
 
   public $hasMany = array(
-    "ElectorDataFilterPrecedence" => array('dependent' => true)
+    "ElectorDataFilter.ElectorDataFilterPrecedence" => array('dependent' => true)
   );
 
   // The context(s) this filter supports

--- a/app/AvailablePlugin/ElectorDataFilter/Model/ElectorDataFilterPrecedence.php
+++ b/app/AvailablePlugin/ElectorDataFilter/Model/ElectorDataFilterPrecedence.php
@@ -59,7 +59,8 @@ class ElectorDataFilterPrecedence extends AppModel
     ),
     'ordr' => array(
       'rule' => 'numeric',
-      'required' => true
+      'required' => false, // XXX We disable presence validation since we will handle it manually in the beforeSave Callback
+      'allowEmpty' => true,
     ),
     'elector_data_filter_id' => array(
       'rule' => 'numeric',

--- a/app/AvailablePlugin/ElectorDataFilter/View/ElectorDataFilterPrecedences/fields.inc
+++ b/app/AvailablePlugin/ElectorDataFilter/View/ElectorDataFilterPrecedences/fields.inc
@@ -168,7 +168,6 @@ $this->Html->addCrumb($crumbTxt);
       <div class="field-name">
         <div class="field-title">
           <?php print ($e ? $this->Form->label('ordr', _txt('fd.order')) : _txt('fd.order')); ?>
-          <span class="required">*</span>
         </div>
         <div class="field-desc"><?php print _txt('pl.elector_data_filter_precedence.order.desc'); ?></div>
       </div>


### PR DESCRIPTION
- After completing the initial "add" page, the user should be redirected back to the same page (to add Precedence rules) rather than the Data Filter plugin index.
- The possible values for attribute_name ("Subject Attribute") should be presented in alphabetical order.
- For consistency with other Enums, tie_break_mode and replacement_mode should be varchar(2)
- Make Precedence form field order optional and allow save