### PR TITLE
CO-2538_ADOdb_Throws_Errors_Under_PHP_8.1

### DIFF
--- a/app/Vendor/adodb5/adodb.inc.php
+++ b/app/Vendor/adodb5/adodb.inc.php
@@ -1547,7 +1547,13 @@ if (!defined('_ADODB_LAYER')) {
 			}
 			$this->_queryID = _adodb_debug_execute($this, $sql,$inputarr);
 		} else {
-			$this->_queryID = @$this->_query($sql,$inputarr);
+			// Disable error reporting directly from the library. Report according
+			// to ADOdb debug configuration
+			error_reporting(0);
+			ini_set('display_errors',0);
+			$this->_queryID = $this->_query($sql,$inputarr);
+			error_reporting(E_ALL);
+			ini_set('display_errors',1);
 		}
 
 		// ************************


### PR DESCRIPTION
- Use IF EXISTS for verfion >9.6
- Skip pg_query default error reporting
- Refactor alter table row queries construction.