### PR TITLE
CO-2538_ADOdb_Throws_Errors_Under_PHP_8.1_PART2

### DIFF
--- a/app/Vendor/adodb5/datadict/datadict-postgres.inc.php
+++ b/app/Vendor/adodb5/datadict/datadict-postgres.inc.php
@@ -236,6 +236,10 @@ class ADODB2_postgres extends ADODB_DataDict
 
 				$existing = $this->metaColumns($tabname);
 				list(,$colname,$default) = $matches;
+				// The column did not exist in the table so there is nothing to alter.
+				if(!isset($existing[strtoupper($colname)])) {
+					continue;
+				}
 				$alter .= $colname;
 				if ($this->connection) {
 					$old_coltype = $this->connection->metaType($existing[strtoupper($colname)]);


### PR DESCRIPTION
ADOdb skip alter step if the table did not contain the row