### PR TITLE
CO-2569_Internal_Error_when_expunging_CO_Person

### DIFF
--- a/app/AvailablePlugin/ApiProvisioner/Model/CoApiProvisionerTarget.php
+++ b/app/AvailablePlugin/ApiProvisioner/Model/CoApiProvisionerTarget.php
@@ -220,18 +220,21 @@ class CoApiProvisionerTarget extends CoProvisionerPluginTarget {
    * @param  array            $coApiProvisionerTarget CoApiProvisioningTarget
    * @param  Integer          $coPersonId             CoPerson ID
    * @param  Array            $identifiers            Array of person's identifiers
-   * @return boolean          true
+   * @return boolean
    * @throws RuntimeException
    */
   
   protected function deletePerson($coApiProvisionerTarget,
                                   $coPersonId,
                                   $identifiers) {
+    if(empty($identifiers)) {
+      return false;
+    }
+
     // Find the identifier of the requested identifier type
     // Note similar logic in deletePerson
     
     $identifierType = $coApiProvisionerTarget['identifier_type'];
-    $identifier = null;
     
     $ids = Hash::extract($identifiers, '{n}[type='.$identifierType.']');
 

--- a/app/Plugin/LdapProvisioner/Model/CoLdapProvisionerTarget.php
+++ b/app/Plugin/LdapProvisioner/Model/CoLdapProvisionerTarget.php
@@ -1620,6 +1620,7 @@ class CoLdapProvisionerTarget extends CoProvisionerPluginTarget {
     $rename   = false;
     $person   = false;
     $group    = false;
+    $errorlevel = error_reporting();
     
     if(!empty($provisioningData['CoGroup']['id'])) {
       $group = true;
@@ -1835,11 +1836,15 @@ class CoLdapProvisionerTarget extends CoProvisionerPluginTarget {
       if($dns['olddn'] && ($rename || !$dns['newdn'])) {
         // Use the old DN if we're renaming or if there is no new DN
         // (which should be the case for a delete operation).
-        @ldap_delete($cxn, $dns['olddn']);
+        error_reporting(0);
+        ldap_delete($cxn, $dns['olddn']);
+        error_reporting($errorlevel);
       } elseif($dns['newdn']) {
         // It's actually not clear when we'd get here -- perhaps cleaning up
         // a record that exists in LDAP even though it's new to Registry?
-        @ldap_delete($cxn, $dns['newdn']);
+        error_reporting(0);
+        ldap_delete($cxn, $dns['newdn']);
+        error_reporting($errorlevel);
       }
       
       if($deletedn) {


### PR DESCRIPTION
- Refactor obsolete operator in LdapProvisioner plugin
- Abort Person Delete API provisioning in case the Person has no Identifiers