### PR TITLE
CO-2616_Error_when_duplicating_a_CO_that_has_a_configured_SqlProvisioner_Provisioning_Target

### DIFF
--- a/app/Model/Co.php
+++ b/app/Model/Co.php
@@ -510,8 +510,10 @@ class Co extends AppModel {
               foreach($corem->duplicatableModels as $dupeModelName => $dupecfg) {
                 // Probably need to load the model
                 $dupem = ClassRegistry::init($pluginName . "." . $dupeModelName);
-                
-                $this->duplicateObjects($dupem, $dupecfg['fk'], array_keys($idmap[$dupecfg['parent']]), $idmap);
+                // Skip duplication if no records exist
+                if(!empty($idmap[$dupecfg['parent']])) {
+                  $this->duplicateObjects($dupem, $dupecfg['fk'], array_keys($idmap[$dupecfg['parent']]), $idmap);
+                }
               }
             } else {
               // Duplicate the main plugin object


### PR DESCRIPTION
Skip LdapProvisioner object duplication when there is no configured object