### PR TITLE
CO-2257_CoMessageTemplate_should_strip_whitespace_from_mail_addresses_in_CC_and_BCC

### DIFF
--- a/app/AvailablePlugin/RecoveryWidget/Model/RecoveryWidget.php
+++ b/app/AvailablePlugin/RecoveryWidget/Model/RecoveryWidget.php
@@ -264,11 +264,11 @@ class RecoveryWidget extends AppModel {
 
     // Add cc and bcc if specified
     if($mt['CoMessageTemplate']['cc']) {
-      $email->cc(explode(',', $mt['CoMessageTemplate']['cc']));
+      $email->cc(array_map('trim', explode(',', $mt['CoMessageTemplate']['cc'])));
     }
 
     if($mt['CoMessageTemplate']['bcc']) {
-      $email->bcc(explode(',', $mt['CoMessageTemplate']['bcc']));
+      $email->bcc(array_map('trim', explode(',', $mt['CoMessageTemplate']['bcc'])));
     }
     
     $msgBody = array();

--- a/app/Model/AuthenticatorBackend.php
+++ b/app/Model/AuthenticatorBackend.php
@@ -204,11 +204,11 @@ abstract class AuthenticatorBackend extends AppModel {
 
     // Add cc and bcc if specified
     if($mt['CoMessageTemplate']['cc']) {
-      $email->cc(explode(',', $mt['CoMessageTemplate']['cc']));
+      $email->cc(array_map('trim', explode(',', $mt['CoMessageTemplate']['cc'])));
     }
 
     if($mt['CoMessageTemplate']['bcc']) {
-      $email->bcc(explode(',', $mt['CoMessageTemplate']['bcc']));
+      $email->bcc(array_map('trim', explode(',', $mt['CoMessageTemplate']['bcc'])));
     }
     
     $msgBody = array();

--- a/app/Model/CoInvite.php
+++ b/app/Model/CoInvite.php
@@ -362,11 +362,11 @@ class CoInvite extends AppModel {
           
           // If cc's or bcc's were set, convert to an array
           if($cc) {
-            $email->cc(explode(',', $cc));
+            $email->cc(array_map('trim', explode(',', $cc)));
           }
           
           if($bcc) {
-            $email->bcc(explode(',', $bcc));
+            $email->bcc(array_map('trim', explode(',', $bcc)));
           }
 
           if($format === MessageFormatEnum::PlaintextAndHTML

--- a/app/Model/CoNotification.php
+++ b/app/Model/CoNotification.php
@@ -963,11 +963,11 @@ class CoNotification extends AppModel {
       
       // Add cc and bcc if specified
       if($cc) {
-        $email->cc(explode(',', $cc));
+        $email->cc(array_map('trim', explode(',', $cc)));
       }
       
       if($bcc) {
-        $email->bcc(explode(',', $bcc));
+        $email->bcc(array_map('trim', explode(',', $bcc)));
       }
 
       if($format === MessageFormatEnum::PlaintextAndHTML


### PR DESCRIPTION
Trim whitespace from cc, bcc email addresses