### PR TITLE
make all .co-info-topbox blocks consistent and move away from jQuery UI classes (CO-2672)

### DIFF
--- a/app/AvailablePlugin/ApiProvisioner/View/CoApiProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/ApiProvisioner/View/CoApiProvisionerTargets/fields.inc
@@ -62,8 +62,10 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_co_api_provisioner_target" class="fields form-list form-list-admin">

--- a/app/AvailablePlugin/ApiSource/View/ApiSources/fields.inc
+++ b/app/AvailablePlugin/ApiSource/View/ApiSources/fields.inc
@@ -85,8 +85,10 @@
     </div>
 <?php if(!empty($vv_api_endpoint)): ?>
     <div class="co-info-topbox">
-      <i class="material-icons">info</i>
-      <?php print _txt('pl.apisource.info', array($vv_api_endpoint)); ?>
+      <em class="material-icons">info</em>
+      <div class="co-info-topbox-text">
+        <?php print _txt('pl.apisource.info', array($vv_api_endpoint)); ?>
+      </div>
     </div>
 <?php endif; // $vv_api_endpoint ?>
     <ul class="field-children">
@@ -166,8 +168,10 @@
         <div class="field-info">
           <?php if(empty($vv_servers)): ?>
           <div class="co-info-topbox">
-            <i class="material-icons">info</i>
-            <?php print _txt('pl.apisource.servers.none'); ?>
+            <em class="material-icons">info</em>
+            <div class="co-info-topbox-text">
+              <?php print _txt('pl.apisource.servers.none'); ?>
+            </div>
           </div>
           <?php else: // vv_servers ?>
           <?php

--- a/app/AvailablePlugin/CertificateAuthenticator/View/CertificateAuthenticators/fields.inc
+++ b/app/AvailablePlugin/CertificateAuthenticator/View/CertificateAuthenticators/fields.inc
@@ -41,6 +41,8 @@
 
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('in.pl.noconfig'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.pl.noconfig'); ?>
+  </div>
 </div>

--- a/app/AvailablePlugin/ChangelogProvisioner/View/CoChangelogProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/ChangelogProvisioner/View/CoChangelogProvisionerTargets/fields.inc
@@ -41,8 +41,10 @@
   print $this->Form->hidden('co_provisioning_target_id', array('default' => $vv_ptid)) . "\n";
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.changelogprovisioner.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.changelogprovisioner.info'); ?>
+  </div>
 </div>
 <ul id="<?php print $this->action; ?>_co_changelog_provisioner_target" class="fields form-list form-list-admin">
   <li>

--- a/app/AvailablePlugin/CrowdProvisioner/View/CoCrowdProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/CrowdProvisioner/View/CoCrowdProvisionerTargets/fields.inc
@@ -62,8 +62,10 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_co_crowd_provisioner_target" class="fields form-list form-list-admin">

--- a/app/AvailablePlugin/FileSource/View/FileSources/fields.inc
+++ b/app/AvailablePlugin/FileSource/View/FileSources/fields.inc
@@ -60,8 +60,10 @@
   print $this->Form->hidden('org_identity_source_id', array('default' => $vv_oisid)) . "\n";
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.filesource.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.filesource.info'); ?>
+  </div>
 </div>
 <ul id="<?php print $this->action; ?>_file_source_target" class="fields form-list form-list-admin">
   <li>

--- a/app/AvailablePlugin/GithubProvisioner/View/CoGithubProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/GithubProvisioner/View/CoGithubProvisionerTargets/fields.inc
@@ -58,20 +58,26 @@
 </script>
 <?php if(empty($co_github_provisioner_targets[0]['CoGithubProvisionerTarget']['client_id'])): ?>
   <div class="co-info-topbox">
-    <i class="material-icons">info</i>
-    <?php print _txt('pl.githubprovisioner.register',
-      array($this->Html->url($vv_github_callback_url, true))); ?>
+    <em class="material-icons">info</em>
+    <div class="co-info-topbox-text">
+      <?php print _txt('pl.githubprovisioner.register',
+        array($this->Html->url($vv_github_callback_url, true))); ?>
+    </div>
   </div>
 <?php elseif(empty($co_github_provisioner_targets[0]['CoGithubProvisionerTarget']['access_token'])): ?>
   <div class="co-info-topbox">
-    <i class="material-icons">info</i>
-    <?php print _txt('pl.githubprovisioner.token.none'); ?>
+    <em class="material-icons">info</em>
+    <div class="co-info-topbox-text">
+      <?php print _txt('pl.githubprovisioner.token.none'); ?>
+    </div>
   </div>
 <?php endif; // client_id/access_token ?>
 <?php if(!$vv_github_type): ?>
   <div class="co-info-topbox">
-    <i class="material-icons">info</i>
-    <?php print _txt('pl.githubprovisioner.type', array($this->Html->url($vv_extended_type_url))); ?>
+    <em class="material-icons">info</em>
+    <div class="co-info-topbox-text">
+      <?php print _txt('pl.githubprovisioner.type', array($this->Html->url($vv_extended_type_url))); ?>
+    </div>
   </div>
 <?php endif; // github_type ?>
 

--- a/app/AvailablePlugin/HomedirProvisioner/View/CoHomedirProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/HomedirProvisioner/View/CoHomedirProvisionerTargets/fields.inc
@@ -41,6 +41,8 @@
   print $this->Form->hidden('co_provisioning_target_id', array('default' => $vv_ptid)) . "\n";
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('in.pl.noconfig'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.pl.noconfig'); ?>
+  </div>
 </div>

--- a/app/AvailablePlugin/JiraProvisioner/View/CoJiraProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/JiraProvisioner/View/CoJiraProvisionerTargets/fields.inc
@@ -62,8 +62,10 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_co_jira_provisioner_target" class="fields form-list form-list-admin">

--- a/app/AvailablePlugin/LdapIdentifierValidator/View/LdapIdentifierValidator/fields.inc
+++ b/app/AvailablePlugin/LdapIdentifierValidator/View/LdapIdentifierValidator/fields.inc
@@ -63,8 +63,10 @@
   // XXX lots of duplication across the various LDAP plugins...
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.ldapsource.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.ldapsource.info'); ?>
+  </div>
 </div>
 <ul id="<?php print $this->action; ?>_ldap_identifier_validator" class="fields form-list form-list-admin">
   <li>

--- a/app/AvailablePlugin/LdapSource/View/LdapSources/fields.inc
+++ b/app/AvailablePlugin/LdapSource/View/LdapSources/fields.inc
@@ -61,8 +61,10 @@
 
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.ldapsource.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.ldapsource.info'); ?>
+  </div>
 </div>
 <ul id="<?php print $this->action; ?>_ldap_source_target" class="fields form-list form-list-admin">
     <li>

--- a/app/AvailablePlugin/MailmanProvisioner/View/CoMailmanProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/MailmanProvisioner/View/CoMailmanProvisionerTargets/fields.inc
@@ -41,12 +41,16 @@
   print $this->Form->hidden('co_provisioning_target_id', array('default' => $vv_ptid)) . "\n";
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.mailmanprovisioner.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.mailmanprovisioner.info'); ?>
+  </div>
 </div>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.mailmanprovisioner.info2'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.mailmanprovisioner.info2'); ?>
+  </div>
 </div>
 
   <ul id="<?php print $this->action; ?>_co_mailman_provisioner_target" class="fields form-list form-list-admin">

--- a/app/AvailablePlugin/MeemEnroller/View/MeemReminders/remind.ctp
+++ b/app/AvailablePlugin/MeemEnroller/View/MeemReminders/remind.ctp
@@ -54,6 +54,7 @@
 ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
   <?php
     if($due === null) {
       print _txt('pl.meemenroller.remind.message');
@@ -63,6 +64,7 @@
       print _txt('pl.meemenroller.remind.message.soon', array($due));
     }
   ?>
+  </div>
 </div>
 <?php
   if($due !== 0 && !empty($vv_return_url)) {

--- a/app/AvailablePlugin/MidPointProvisioner/View/CoMidPointProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/MidPointProvisioner/View/CoMidPointProvisionerTargets/fields.inc
@@ -42,8 +42,11 @@
 ?>
 
 <?php if (empty($vv_servers)): ?>
-<div class="co-info-topbox"><i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::HttpServer))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_co_mid_point_provisioner_target" class="fields form-list form-list-admin">

--- a/app/AvailablePlugin/NamespaceAssigner/View/NamespaceAssignerSettings/fields.inc
+++ b/app/AvailablePlugin/NamespaceAssigner/View/NamespaceAssignerSettings/fields.inc
@@ -54,8 +54,10 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('ct.http_servers.1'))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('ct.http_servers.1'))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_namespace_assigner_settings" class="fields form-list form-list-admin">

--- a/app/AvailablePlugin/NetForumSource/View/NetForumSources/fields.inc
+++ b/app/AvailablePlugin/NetForumSource/View/NetForumSources/fields.inc
@@ -61,8 +61,10 @@
 
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.netforumsource.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.netforumsource.info'); ?>
+  </div>
 </div>
 <ul id="<?php print $this->action; ?>_net_forum_source" class="fields form-list form-list-admin">
   <li>

--- a/app/AvailablePlugin/NoviSource/View/NoviSources/fields.inc
+++ b/app/AvailablePlugin/NoviSource/View/NoviSources/fields.inc
@@ -63,8 +63,10 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('ct.http_servers.1'))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('ct.http_servers.1'))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_novi_sources" class="fields form-list">

--- a/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/fields.inc
+++ b/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/fields.inc
@@ -47,7 +47,8 @@
 ?>
 
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
   <?php
     if($vv_authenticator['PasswordAuthenticator']['password_source'] == PasswordAuthPasswordSourceEnum::SelfSelect) {
       $maxlen = isset($vv_authenticator['PasswordAuthenticator']['max_length'])
@@ -64,6 +65,7 @@
       print _txt('pl.passwordauthenticator.noedit');
     }
   ?>
+  </div>
 </div>
 
 <?php if($vv_authenticator['PasswordAuthenticator']['password_source'] == PasswordAuthPasswordSourceEnum::AutoGenerate): ?>

--- a/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/generate.ctp
+++ b/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/generate.ctp
@@ -31,9 +31,11 @@
   // Add breadcrumbs
   print $this->element("coCrumb", array('authenticator' => 'Password'));
 ?>
-<div class="ui-state-highlight ui-corner-all co-info-topbox">
-  <span class="ui-icon ui-icon-info co-info"></span>
-  <strong><?php print _txt('pl.passwordauthenticator.password.info'); ?></strong>
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.passwordauthenticator.password.info'); ?>
+  </div>
 </div>
 
 <ul id="<?php print $this->action; ?>_passwords" class="fields form-list">

--- a/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/remind.ctp
+++ b/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/remind.ctp
@@ -50,9 +50,11 @@
   }
 ?>
 <?php if(!empty($this->request->params['named']['authenticatorid']) && empty($vv_token)): ?>
-<div class="ui-state-highlight ui-corner-all co-info-topbox">
-  <span class="ui-icon ui-icon-info co-info"></span>
-  <strong><?php print _txt('pl.passwordauthenticator.usernamereminder.info'); ?></strong>
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.passwordauthenticator.usernamereminder.info'); ?>
+  </div>
 </div>
 
 <ul id="<?php print $this->action; ?>_usernamereminder" class="fields form-list">

--- a/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/ssr.ctp
+++ b/app/AvailablePlugin/PasswordAuthenticator/View/Passwords/ssr.ctp
@@ -47,9 +47,11 @@
   // This should merge with fields.inc to render password constraints, but we
   // don't currently have access to vv_authenticator (since we only have a token)
 ?>
-<div class="ui-state-highlight ui-corner-all co-info-topbox">
-  <span class="ui-icon ui-icon-info co-info"></span>
-  <strong><?php print _txt('pl.passwordauthenticator.ssr.for', array($vv_name)); ?></strong>
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.passwordauthenticator.ssr.for', array($vv_name)); ?>
+  </div>
 </div>
 
 <ul id="<?php print $this->action; ?>_ssr" class="fields form-list">

--- a/app/AvailablePlugin/PasswordWidget/View/CoPasswordWidgets/fields.inc
+++ b/app/AvailablePlugin/PasswordWidget/View/CoPasswordWidgets/fields.inc
@@ -69,13 +69,17 @@
 
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('pl.passwordwidget.info.dependency'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.passwordwidget.info.dependency'); ?>
+  </div>
 </div>
 
 <?php if(count($vv_available_authenticators) < 1): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('er.passwordwidget.no.passwordauthenticators'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('er.passwordwidget.no.passwordauthenticators'); ?>
+    </div>
   </div>
 <?php endif; ?>
 

--- a/app/AvailablePlugin/RecoveryWidget/View/Actions/lookup.ctp
+++ b/app/AvailablePlugin/RecoveryWidget/View/Actions/lookup.ctp
@@ -43,7 +43,7 @@
 ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <span class="co-info-topbox-text">
+  <div class="co-info-topbox-text">
   <?php 
     // For the password reset action, we pass in a link to direct password change
     if(!empty($vv_authenticator_change_url)) {
@@ -52,7 +52,7 @@
       print _txt("pl.recoverywidget.lookup.$vv_task.info");
     }
   ?>
-  </span>
+  </div>
 </div>
 
 <ul id="<?php print $this->action; ?>_recovery" class="fields form-list">

--- a/app/AvailablePlugin/SalesforceProvisioner/View/CoSalesforceProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/SalesforceProvisioner/View/CoSalesforceProvisionerTargets/fields.inc
@@ -82,8 +82,10 @@
 </script>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::Oauth2Server))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::Oauth2Server))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_co_salesforce_provisioner_target" class="fields form-list form-list-admin">

--- a/app/AvailablePlugin/SalesforceSource/View/SalesforceSources/fields.inc
+++ b/app/AvailablePlugin/SalesforceSource/View/SalesforceSources/fields.inc
@@ -63,8 +63,10 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('ct.oauth2_servers.1'))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('ct.oauth2_servers.1'))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_salesforce_source" class="fields form-list">

--- a/app/AvailablePlugin/ServiceEligibilityEnroller/View/ServiceEligibilityEnrollers/fields.inc
+++ b/app/AvailablePlugin/ServiceEligibilityEnroller/View/ServiceEligibilityEnrollers/fields.inc
@@ -75,6 +75,8 @@
   print $this->Form->hidden('co_enrollment_flow_wedge_id', array('default' => $service_eligibility_enrollers[0]['CoEnrollmentFlowWedge']['id'])) . "\n";
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('in.pl.noconfig'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.pl.noconfig'); ?>
+  </div>
 </div>

--- a/app/AvailablePlugin/SponsorManager/View/Sponsors/review.ctp
+++ b/app/AvailablePlugin/SponsorManager/View/Sponsors/review.ctp
@@ -34,8 +34,9 @@ $title = _txt('pl.sponsormanager.sponsor', array(generateCn($vv_sponsor['Primary
 print $this->element("pageTitle", array('title' => $title));
 ?>
 <?php if(!empty($vv_settings['SponsorManagerSetting']['renewal_window'])): ?>
-<div class="co-info-topbox">
+  <div class="co-info-topbox">
   <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
   <?php
     // Calculate the start of the renewal window, as now+window. In other
     // words, if today is March 1 and the renewal window is 30 days, we'll
@@ -44,6 +45,7 @@ print $this->element("pageTitle", array('title' => $title));
     
     print _txt('pl.sponsormanager.renewal_window.info', array($renewalWindowStart->format("j M Y")));
   ?>
+  </div>
 </div>
 <?php endif; ?>
 

--- a/app/AvailablePlugin/SqlProvisioner/View/CoSqlProvisionerTargets/fields.inc
+++ b/app/AvailablePlugin/SqlProvisioner/View/CoSqlProvisionerTargets/fields.inc
@@ -62,13 +62,17 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::SqlServer))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::SqlServer))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.sqlprovisioner.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.sqlprovisioner.info'); ?>
+  </div>
 </div>
 <ul id="<?php print $this->action; ?>_co_sql_provisioner_target" class="fields form-list form-list-admin">
   <li>

--- a/app/Plugin/CoreApi/View/CoreApis/fields.inc
+++ b/app/Plugin/CoreApi/View/CoreApis/fields.inc
@@ -124,8 +124,10 @@
 </script>
 <?php if(!empty($vv_api_endpoint)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.coreapi.info', array($vv_api_endpoint)); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.coreapi.info', array($vv_api_endpoint)); ?>
+  </div>
 </div>
 <?php endif; // $vv_api_endpoint ?>
 <ul id="<?php print $this->action; ?>_core_apis" class="fields form-list">

--- a/app/Plugin/GrouperProvisioner/View/CoGrouperProvisionerTargets/fields.inc
+++ b/app/Plugin/GrouperProvisioner/View/CoGrouperProvisionerTargets/fields.inc
@@ -67,8 +67,10 @@
   }
 </script>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.grouperprovisioner.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.grouperprovisioner.info'); ?>
+  </div>
 </div>
 <ul id="<?php print $this->action; ?>_co_grouper_provisioner_target" class="fields form-list form-list-admin">
   <li>

--- a/app/Plugin/LdapProvisioner/View/CoLdapProvisionerTargets/fields.inc
+++ b/app/Plugin/LdapProvisioner/View/CoLdapProvisionerTargets/fields.inc
@@ -135,8 +135,10 @@
   }
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('pl.ldapprovisioner.info'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('pl.ldapprovisioner.info'); ?>
+  </div>
 </div>
 
 <ul id="<?php print $this->action; ?>_co_ldap_provisioner_target" class="fields form-list form-list-admin">

--- a/app/Plugin/OrcidSource/View/OrcidSources/fields.inc
+++ b/app/Plugin/OrcidSource/View/OrcidSources/fields.inc
@@ -63,8 +63,10 @@
 ?>
 <?php if(empty($vv_servers)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::Oauth2Server))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.server.none', array(_txt('en.server', null, ServerEnum::Oauth2Server))); ?>
+  </div>
 </div>
 <?php else: // vv_servers ?>
 <ul id="<?php print $this->action; ?>_orcid_source" class="fields form-list">

--- a/app/Plugin/SshKeyAuthenticator/View/SshKeyAuthenticators/fields.inc
+++ b/app/Plugin/SshKeyAuthenticator/View/SshKeyAuthenticators/fields.inc
@@ -41,6 +41,8 @@
 
 ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('in.pl.noconfig'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.pl.noconfig'); ?>
+  </div>
 </div>

--- a/app/View/ApiUsers/fields.inc
+++ b/app/View/ApiUsers/fields.inc
@@ -60,7 +60,9 @@
 <?php if($cur_co['Co']['name'] == DEF_COMANAGE_CO_NAME): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.api.cmp'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.api.cmp'); ?>
+  </div>
 </div>
 <?php endif; // co name == DEF_COMANAGE_CO_NAME ?>
 <ul id="<?php print $this->action; ?>_api_users" class="fields form-list">

--- a/app/View/ApiUsers/generate.ctp
+++ b/app/View/ApiUsers/generate.ctp
@@ -36,9 +36,11 @@
   $crumbTxt = _txt('op.api.key.generate');
   $this->Html->addCrumb($crumbTxt);
 ?>
-<div class="ui-state-highlight ui-corner-all co-info-topbox">
-  <span class="ui-icon ui-icon-info co-info"></span>
-  <strong><?php print _txt('in.api.key'); ?></strong>
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.api.key'); ?>
+  </div>
 </div>
 
 <ul id="<?php print $this->action; ?>_api_users" class="fields form-list">

--- a/app/View/ApiUsers/index.ctp
+++ b/app/View/ApiUsers/index.ctp
@@ -53,7 +53,9 @@
 <?php if($cur_co['Co']['name'] == DEF_COMANAGE_CO_NAME): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.api.cmp'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.api.cmp'); ?>
+  </div>
 </div>
 <?php endif; // co name == DEF_COMANAGE_CO_NAME ?>
 

--- a/app/View/Authenticators/fields.inc
+++ b/app/View/Authenticators/fields.inc
@@ -51,8 +51,10 @@
 ?>
 <?php if(empty($plugins)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.plugin.none', array(_txt('ct.authenticators.pl'))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.plugin.none', array(_txt('ct.authenticators.pl'))); ?>
+  </div>
 </div>
 <?php else: /* plugins */ ?>
 <ul id="<?php print $this->action; ?>_authenticator" class="fields form-list">

--- a/app/View/Clusters/fields.inc
+++ b/app/View/Clusters/fields.inc
@@ -51,8 +51,10 @@
 ?>
 <?php if(empty($plugins)): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('er.plugin.none', array(_txt('ct.clusters.pl'))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.plugin.none', array(_txt('ct.clusters.pl'))); ?>
+  </div>
 </div>
 <?php else: /* plugins */ ?>
 <ul id="<?php print $this->action; ?>_cluster" class="fields form-list">

--- a/app/View/CoGroupMembers/co_group_members_body.inc
+++ b/app/View/CoGroupMembers/co_group_members_body.inc
@@ -31,7 +31,9 @@
     <td colspan="5">
       <div class="co-info-topbox">
         <em class="material-icons">info</em>
-        <?php print _txt('in.co_group.people.none_filters'); ?>
+        <div class="co-info-topbox-text">
+          <?php print _txt('in.co_group.people.none_filters'); ?>
+        </div>
       </div>
     </td>
   </tr>
@@ -40,7 +42,9 @@
     <td colspan="5">
       <div class="co-info-topbox">
         <em class="material-icons">info</em>
-        <?php print _txt('in.co_group.people.none'); ?>
+        <div class="co-info-topbox-text">
+          <?php print _txt('in.co_group.people.none'); ?>
+        </div>
       </div>
     </td>
   </tr>

--- a/app/View/CoGroupMembers/co_people_body.inc
+++ b/app/View/CoGroupMembers/co_people_body.inc
@@ -31,7 +31,9 @@
     <td colspan="5">
       <div class="co-info-topbox">
         <em class="material-icons">info</em>
-        <?php print _txt('in.co_group.people.none_filters'); ?>
+        <div class="co-info-topbox-text">
+          <?php print _txt('in.co_group.people.none_filters'); ?>
+        </div>
       </div>
     </td>
   </tr>
@@ -40,7 +42,9 @@
     <td colspan="5">
       <div class="co-info-topbox">
         <em class="material-icons">info</em>
-        <?php print _txt('in.co_group.people.none'); ?>
+        <div class="co-info-topbox-text">
+          <?php print _txt('in.co_group.people.none'); ?>
+        </div>
       </div>
     </td>
   </tr>

--- a/app/View/CoGroupMembers/index.ctp
+++ b/app/View/CoGroupMembers/index.ctp
@@ -62,7 +62,9 @@
 <?php if($co_group['CoGroup']['auto']): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('in.co_group.auto', array($cur_co['Co']['id'])); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('in.co_group.auto', array($cur_co['Co']['id'])); ?>
+    </div>
   </div>
 <?php endif; ?>
 

--- a/app/View/CoGroups/index.ctp
+++ b/app/View/CoGroups/index.ctp
@@ -328,7 +328,9 @@
           <td colspan="5">
             <div class="co-info-topbox">
               <em class="material-icons">info</em>
-              <?php print _txt('in.co_group.none_filters'); ?>
+              <div class="co-info-topbox-text">
+                <?php print _txt('in.co_group.none_filters'); ?>
+              </div>
             </div>
           </td>
         </tr>
@@ -337,7 +339,9 @@
           <td colspan="5">
             <div class="co-info-topbox">
               <em class="material-icons">info</em>
-              <?php print _txt('in.co_group.none'); ?>
+              <div class="co-info-topbox-text">
+                <?php print _txt('in.co_group.none'); ?>
+              </div>
             </div>
           </td>
         </tr>

--- a/app/View/CoIdentifierValidators/index.ctp
+++ b/app/View/CoIdentifierValidators/index.ctp
@@ -53,7 +53,9 @@
 <?php if(empty($vv_plugins)): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('in.idval.plugins'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('in.idval.plugins'); ?>
+    </div>
   </div>
 <?php else: // vv_plugins ?>
   <div class="table-container">

--- a/app/View/CoInvites/reply.ctp
+++ b/app/View/CoInvites/reply.ctp
@@ -28,7 +28,9 @@
 <?php if(isset($vv_confirmation_expired) && $vv_confirmation_expired): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.inv.exp.resent'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.inv.exp.resent'); ?>
+  </div>
 </div>
 <?php else: /* $vv_confirmation_expired */ ?>
 <?php if(!empty($invite)): ?>

--- a/app/View/CoJobs/fields.inc
+++ b/app/View/CoJobs/fields.inc
@@ -56,9 +56,11 @@
 <?php if(!empty($vv_lock_info)): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.job.running', array($vv_lock_info['Lock']['pid'], 
-                                           $vv_lock_info['Lock']['id'],
-                                           $this->Time->niceShort($vv_lock_info['Lock']['created'], $vv_tz))); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.job.running', array($vv_lock_info['Lock']['pid'], 
+                                             $vv_lock_info['Lock']['id'],
+                                             $this->Time->niceShort($vv_lock_info['Lock']['created'], $vv_tz))); ?>
+  </div>
 </div>
 <?php endif; // vv_lock_info ?>
 <script type="text/javascript">

--- a/app/View/CoJobs/index.ctp
+++ b/app/View/CoJobs/index.ctp
@@ -36,9 +36,11 @@
 <?php if(!empty($vv_lock_info)): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.job.running', array($vv_lock_info['Lock']['pid'], 
-                                           $vv_lock_info['Lock']['id'],
-                                           $this->Time->niceShort($vv_lock_info['Lock']['created'], $vv_tz))); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.job.running', array($vv_lock_info['Lock']['pid'], 
+                                             $vv_lock_info['Lock']['id'],
+                                             $this->Time->niceShort($vv_lock_info['Lock']['created'], $vv_tz))); ?>
+  </div>
 </div>
 <?php endif; // vv_lock_info ?>
 <?php

--- a/app/View/CoPeople/expunge.ctp
+++ b/app/View/CoPeople/expunge.ctp
@@ -79,8 +79,10 @@
 <?php else: ?>
  <div class="co-info-topbox">
 <?php endif; ?>
-  <em class="material-icons mr-1">info</em>
-  <?php print _txt('op.expunge.confirm', array(filter_var(generateCn($vv_co_person['PrimaryName']),FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('op.expunge.confirm', array(filter_var(generateCn($vv_co_person['PrimaryName']),FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+  </div>
 </div>
 <div class="innerContent">
   <p>

--- a/app/View/CoPeople/index.ctp
+++ b/app/View/CoPeople/index.ctp
@@ -74,25 +74,33 @@
 <?php if($this->action == 'link'): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('op.link.select', array(filter_var(generateCn($vv_org_identity['PrimaryName']),FILTER_SANITIZE_SPECIAL_CHARS),
-      filter_var($vv_org_identity['OrgIdentity']['id'],FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('op.link.select', array(filter_var(generateCn($vv_org_identity['PrimaryName']),FILTER_SANITIZE_SPECIAL_CHARS),
+        filter_var($vv_org_identity['OrgIdentity']['id'],FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+    </div>
   </div>
 <?php elseif($this->action == 'relink' && !empty($vv_co_org_identity_link['OrgIdentity'])): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('op.relink.select', array(filter_var(generateCn($vv_co_org_identity_link['OrgIdentity']['PrimaryName']),FILTER_SANITIZE_SPECIAL_CHARS),
-      filter_var($vv_co_org_identity_link['OrgIdentity']['id'],FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('op.relink.select', array(filter_var(generateCn($vv_co_org_identity_link['OrgIdentity']['PrimaryName']),FILTER_SANITIZE_SPECIAL_CHARS),
+        filter_var($vv_co_org_identity_link['OrgIdentity']['id'],FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+    </div>
   </div>
 <?php elseif($this->action == 'relink' && !empty($vv_co_person_role['CoPersonRole'])): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('op.relink.role.select', array(filter_var($vv_co_person_role['CoPersonRole']['title'],FILTER_SANITIZE_SPECIAL_CHARS),
-      filter_var($vv_co_person_role['CoPersonRole']['id'],FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('op.relink.role.select', array(filter_var($vv_co_person_role['CoPersonRole']['title'],FILTER_SANITIZE_SPECIAL_CHARS),
+        filter_var($vv_co_person_role['CoPersonRole']['id'],FILTER_SANITIZE_SPECIAL_CHARS))); ?>
+    </div>
   </div>
 <?php elseif($this->action == 'select'): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('op.select.select'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('op.select.select'); ?>
+    </div>
   </div>
 <?php endif; // link ?>
 

--- a/app/View/CoPeople/link.ctp
+++ b/app/View/CoPeople/link.ctp
@@ -101,8 +101,10 @@
 <?php else: ?>
 <div class="co-info-topbox">
  <?php endif; ?>
-  <em class="material-icons mr-1">info</em>
-  <?php print _txt('op.link.confirm'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('op.link.confirm'); ?>
+  </div>
 </div>
 <div class="innerContent">
   <ul>

--- a/app/View/CoPeople/relink-org.ctp
+++ b/app/View/CoPeople/relink-org.ctp
@@ -54,8 +54,10 @@
 <?php else: ?>
 <div class="co-info-topbox">
 <?php endif; ?>
-  <em class="material-icons mr-1">info</em>
-  <?php print _txt('op.relink.confirm'); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('op.relink.confirm'); ?>
+  </div>
 </div>
 <div class="innerContent">
   <ul>

--- a/app/View/CoPeople/relink-role.ctp
+++ b/app/View/CoPeople/relink-role.ctp
@@ -51,7 +51,9 @@
 </script>
 <div class="co-info-topbox lightbox-info">
   <em class="material-icons">info</em>
-  <?php print _txt('op.relink.role.confirm'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('op.relink.role.confirm'); ?>
+  </div>
 </div>
 <div class="innerContent">
   <ul>

--- a/app/View/CoPetitions/duplicate_check.ctp
+++ b/app/View/CoPetitions/duplicate_check.ctp
@@ -36,7 +36,9 @@ print $this->element("pageTitleAndButtons", $params);
 
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.ef.match'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.ef.match'); ?>
+  </div>
 </div>
 
 <div id="reconcile-table-container">

--- a/app/View/CoProvisioningTargets/fields.inc
+++ b/app/View/CoProvisioningTargets/fields.inc
@@ -71,7 +71,9 @@
 <?php if(empty($plugins)): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('er.plugin.none', array(_txt('ct.co_provisioning_targets.pl'))); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.plugin.none', array(_txt('ct.co_provisioning_targets.pl'))); ?>
+  </div>
 </div>
 <?php else: /* plugins */ ?>
 <ul id="<?php print $this->action; ?>_co_provisioning_target" class="fields form-list">

--- a/app/View/CoSelfServicePermissions/index.ctp
+++ b/app/View/CoSelfServicePermissions/index.ctp
@@ -54,7 +54,9 @@
 
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('fd.ssp.default'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('fd.ssp.default'); ?>
+  </div>
 </div>
 
 <div class="table-container">

--- a/app/View/CoTermsAndConditions/review.ctp
+++ b/app/View/CoTermsAndConditions/review.ctp
@@ -91,13 +91,17 @@
 <?php if(empty($vv_co_terms_and_conditions)): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('fd.tc.none'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('fd.tc.none'); ?>
+  </div>
 </div>
 <?php else: // vv_co_terms_and_conditions ?>
 <?php if(isset($this->params['named']['mode']) && $this->params['named']['mode'] == 'login' && $pending): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('fd.tc.agree.login'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('fd.tc.agree.login'); ?>
+    </div>
   </div>
 <?php endif; // mode=login ?>
 <div class="table-container">

--- a/app/View/DataFilters/fields.inc
+++ b/app/View/DataFilters/fields.inc
@@ -56,7 +56,9 @@
 <?php if(empty($plugins)): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('er.plugin.none', array(_txt('ct.data_filters.pl'))); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('er.plugin.none', array(_txt('ct.data_filters.pl'))); ?>
+    </div>
   </div>
 <?php else: /* plugins */ ?>
   <ul id="<?php print $this->action; ?>_data_filter" class="fields form-list form-list-admin">

--- a/app/View/Elements/lastlogin.ctp
+++ b/app/View/Elements/lastlogin.ctp
@@ -38,16 +38,18 @@
 ?>
 <div id="lastLogin">
   <div class="co-info-topbox">
-    <?php foreach($lastlogin as $u => $l): ?>
-    <?php if(!empty($l)): ?>
-    <p>
-      <span class="ui-icon ui-icon-info co-info"></span>
-      <strong><?php print _txt('in.login.last', array($u,
-                                                      $l['AuthenticationEvent']['created'],
-                                                      ($l['AuthenticationEvent']['remote_ip'] ?: "?"))); ?></strong>
-    </p>
-    <?php endif; // !empty ?>
-    <?php endforeach; ?>
+    <em class="material-icons">info</em>
+    <div class="co-info-topbox-text">
+      <?php foreach($lastlogin as $u => $l): ?>
+        <?php if(!empty($l)): ?>
+        <p>
+          <?php print _txt('in.login.last', array($u,
+                                                       $l['AuthenticationEvent']['created'],
+                                                       ($l['AuthenticationEvent']['remote_ip'] ?: "?"))); ?>
+        </p>
+        <?php endif; // !empty ?>
+      <?php endforeach; ?>
+    </div>
   </div>
 </div>
 <?php

--- a/app/View/Identifiers/fields.inc
+++ b/app/View/Identifiers/fields.inc
@@ -48,8 +48,10 @@
 ?>
 <?php if(!empty($identifiers[0]['CoProvisioningTarget']['id'])): ?>
 <div class="co-info-topbox">
-  <i class="material-icons">info</i>
-  <?php print _txt('in.id.prov', array($identifiers[0]['CoProvisioningTarget']['description'])); ?>
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.id.prov', array($identifiers[0]['CoProvisioningTarget']['description'])); ?>
+  </div>
 </div>
 <?php endif; // provisioning target ?>
 

--- a/app/View/OrgIdentities/fields.inc
+++ b/app/View/OrgIdentities/fields.inc
@@ -114,14 +114,18 @@
 <?php if($this->action == 'view' && !empty($org_identities[0]['OrgIdentitySourceRecord']['OrgIdentitySource']['id'])): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('op.orgid.edit.ois', array($org_identities[0]['OrgIdentitySourceRecord']['OrgIdentitySource']['description'])); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('op.orgid.edit.ois', array($org_identities[0]['OrgIdentitySourceRecord']['OrgIdentitySource']['description'])); ?>
+    </div>
   </div>
 <?php endif; // view ?>
 
 <?php if($this->action == 'edit'): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('in.orgidentities'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('in.orgidentities'); ?>
+    </div>
   </div>
 <?php endif; // edit ?>
 

--- a/app/View/OrgIdentities/find.ctp
+++ b/app/View/OrgIdentities/find.ctp
@@ -44,13 +44,17 @@
 <?php if($op == 'invite'): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('in.orgid.email'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('in.orgid.email'); ?>
+    </div>
   </div>
 <?php endif; // invite ?>
 
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.orgid.co'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.orgid.co'); ?>
+  </div>
 </div>
 
 <?php // Load the top search bar

--- a/app/View/OrgIdentities/index.ctp
+++ b/app/View/OrgIdentities/index.ctp
@@ -69,7 +69,9 @@ print $this->element("pageTitleAndButtons", $params);
 
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('in.orgidentities'); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.orgidentities'); ?>
+  </div>
 </div>
 
 <?php // Load the top search bar

--- a/app/View/OrgIdentitySourceRecords/fields.inc
+++ b/app/View/OrgIdentitySourceRecords/fields.inc
@@ -70,7 +70,9 @@
 <?php if($this->action == 'view' && !empty($org_identity_source_records[0]['OrgIdentitySourceRecord']['id'])): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('in.orgid.oisr'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('in.orgid.oisr'); ?>
+    </div>
   </div>
 <?php endif; // view ?>
 

--- a/app/View/OrgIdentitySources/fields.inc
+++ b/app/View/OrgIdentitySources/fields.inc
@@ -93,7 +93,9 @@
 <?php if(empty($plugins)): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('er.plugin.none', array(_txt('ct.org_identity_sources.pl'))); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('er.plugin.none', array(_txt('ct.org_identity_sources.pl'))); ?>
+    </div>
   </div>
 <?php else: /* plugins */ ?>
   <ul id="<?php print $this->action; ?>_org_identity_source" class="fields form-list form-list-admin">

--- a/app/View/OrgIdentitySources/query.ctp
+++ b/app/View/OrgIdentitySources/query.ctp
@@ -73,10 +73,12 @@
 
 <ul id="<?php print $this->action; ?>_ois_query" class="fields form-list">
 <?php if(empty($vv_search_attrs)): ?>
-    <div class="co-info-topbox">
-      <em class="material-icons">info</em>
+  <div class="co-info-topbox">
+    <em class="material-icons">info</em>
+    <div class="co-info-topbox-text">
       <?php print _txt('in.ois.nosearch'); ?>
     </div>
+  </div>
 <?php else: // vv_search_attrs ?>
 <?php
     foreach($vv_search_attrs as $field => $label) {

--- a/app/View/OrgIdentitySources/retrieve.ctp
+++ b/app/View/OrgIdentitySources/retrieve.ctp
@@ -141,21 +141,25 @@
          && !empty($this->request->params['named']['copetitionid'])): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('er.ois.pt.linked'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('er.ois.pt.linked'); ?>
+    </div>
   </div>
 <?php endif; ?>
 <?php if(!empty($vv_ois_record['OrgIdentitySourceRecord']['org_identity_id'])): ?>
   <div class="co-info-topbox">
     <em class="material-icons">info</em>
-    <?php print _txt('in.orgid.ois'); ?>
+    <div class="co-info-topbox-text">
+      <?php print _txt('in.orgid.ois'); ?>
+    </div>
   </div>
 <?php endif; // view ?>
 <?php if(isset($vv_not_found) && $vv_not_found): ?>
-<div class="ui-state-highlight ui-corner-all co-info-topbox">
-  <p>
-    <span class="ui-icon ui-icon-info co-info"></span>
-    <strong><?php print _txt('in.orgid.ois.notfound'); ?></strong>
-  </p>
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('in.orgid.ois.notfound'); ?>
+  </div>
 </div>
 <br />
 <?php else: // vv_not_found ?>

--- a/app/View/Pages/home.ctp
+++ b/app/View/Pages/home.ctp
@@ -70,8 +70,10 @@
 
 <?php if($err != ""): ?>
   <div class="co-info-topbox">
-    <em class="material-icons error">info</em>
-    <?php print $err; ?>
+    <em class="material-icons">info</em>
+    <div class="co-info-topbox-text">
+      <?php print $err; ?>
+    </div>
   </div>
 <?php else: // $err ?>
 <div id="fpDashboard">

--- a/app/View/Standard/view.ctp
+++ b/app/View/Standard/view.ctp
@@ -83,21 +83,21 @@
   }
 ?>
 <?php if(!empty($d[0]['OrgIdentity']['OrgIdentitySourceRecord']['description'])): ?>
-<div class="ui-state-highlight ui-corner-all co-info-topbox">
-  <p>
-    <span class="ui-icon ui-icon-info co-info"></span>
-    <strong><?php
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php
       print _txt('op.orgid.edit.ois', array($d[0]['OrgIdentity']['OrgIdentitySourceRecord']['description']));
-    ?></strong>
-  </p>
+    ?>
+  </div>
 </div>
 <br />
 <?php elseif(!empty($d[0][$req]['source_'.$modelu.'_id'])): ?>
-<div class="ui-state-highlight ui-corner-all co-info-topbox">
-  <p>
-    <span class="ui-icon ui-icon-info co-info"></span>
-    <strong><?php print _txt('op.pipeline.edit.ois'); ?></strong>
-  </p>
+<div class="co-info-topbox">
+  <em class="material-icons">info</em>
+  <div class="co-info-topbox-text">
+    <?php print _txt('op.pipeline.edit.ois'); ?>
+  </div>
 </div>
 <br />
 <?php endif; // readonly ?>

--- a/app/View/VettingSteps/fields.inc
+++ b/app/View/VettingSteps/fields.inc
@@ -52,7 +52,9 @@
 <?php if(empty($plugins)): ?>
 <div class="co-info-topbox">
   <em class="material-icons">info</em>
-  <?php print _txt('er.plugin.none', array(_txt('ct.vetting_steps.pl'))); ?>
+  <div class="co-info-topbox-text">
+    <?php print _txt('er.plugin.none', array(_txt('ct.vetting_steps.pl'))); ?>
+  </div>
 </div>
 <?php else: /* plugins */ ?>
 <ul id="<?php print $this->action; ?>_vetting_step" class="fields form-list">


### PR DESCRIPTION
This PR is very broad (touches many files) but is largely a mechanical change to refactor and make consistent all .co-info-topbox information blocks. It improves both the layout and the styling, and the PR establishes more appropriate markup when the underlying message itself has more complicated, block-level markup.