### PR TITLE
CO-2697_Add_missing_model_associations._Changelog_behavior_to_support_contain_equal_to_true

### DIFF
--- a/app/Model/Behavior/ChangelogBehavior.php
+++ b/app/Model/Behavior/ChangelogBehavior.php
@@ -229,7 +229,11 @@ class ChangelogBehavior extends ModelBehavior {
       $ret['conditions'][] = $malias . '.deleted IS NOT true';
       
       if(!empty($query['contain'])
-         && (!isset($query['contain'][0]) || $query['contain'][0] != false)) {
+         && (!isset($query['contain'][0])
+             || $query['contain'][0] != false
+             || (is_bool($query['contain']) && $query['contain'])
+            )
+      ) {
         $ret['contain'] = $this->modifyContain($model, $query['contain']);
       }
       
@@ -535,6 +539,13 @@ class ChangelogBehavior extends ModelBehavior {
     // If we get a simple string, convert it to a simple array
     if(is_string($contain)) {
       $contain = array(0 => $contain);
+    }
+
+    if(is_bool($contain) && $contain) {
+      // We will create the contain array here by using the associations of the model
+      $has = array_merge($model->hasOne, $model->hasMany);
+      $belongs = $model->belongsTo;
+      $contain = array_merge(array_keys($has), array_keys($belongs));
     }
     
     $ret = $contain;

--- a/app/Model/CoEnrollmentFlow.php
+++ b/app/Model/CoEnrollmentFlow.php
@@ -81,7 +81,7 @@ class CoEnrollmentFlow extends AppModel {
     ),
     "CoTheme",
     "MatchServer" => array(
-      'className' => 'Server',
+      'className' => 'MatchServer',
       'foreignKey' => 'match_server_id'
     )
   );

--- a/app/Model/CoGroup.php
+++ b/app/Model/CoGroup.php
@@ -40,6 +40,10 @@ class CoGroup extends AppModel {
       'dependent' => true,
       'foreignKey' => 'target_co_group_id'
     ),
+    "CoGroupOisMapping" => array(
+      'dependent' => true,
+      'foreignKey' => 'co_group_id'
+    ),
     "SourceCoGroupNesting" => array(
       'dependent' => true,
       'className' => 'CoGroupNesting',

--- a/app/Model/CoPipeline.php
+++ b/app/Model/CoPipeline.php
@@ -37,7 +37,7 @@ class CoPipeline extends AppModel {
     "Co",
     "CoEnrollmentFlow",
     "MatchServer" => array(
-      'className'  => 'Server',
+      'className'  => 'MatchServer',
       'foreignKey' => 'match_server_id'
     ),
     "SyncCou" => array(

--- a/app/Model/DataFilter.php
+++ b/app/Model/DataFilter.php
@@ -42,7 +42,8 @@ class DataFilter extends AppModel {
   );
   
   public $hasMany = array(
-    'CoProvisioningTargetFilter'
+    'CoProvisioningTargetFilter',
+    'OrgIdentitySourceFilter'
   );
   
   public $hasManyPlugins = array(


### PR DESCRIPTION
- Add missing associations Pipeline,CoEnrollmentFlow,CoGroup,DataFilter
- Changelog Behavior enable correct find for contain equals to true.