### PR TITLE
Partition id param fixes + partition soft locking

### DIFF
--- a/app/AvailablePlugin/ApiSource/Lib/lang.php
+++ b/app/AvailablePlugin/ApiSource/Lib/lang.php
@@ -59,6 +59,7 @@ $cm_api_source_texts['en_US'] = array(
   'pl.apisource.job.poll.max'     => 'Maximum number of loops to try (default is 10)',
   'pl.apisource.job.poll.msg'     => 'Processed message at offset %1$s',
   'pl.apisource.job.poll.start'   => 'Polling for new records (mode %1$s)',
+  'pl.apisource.job.existing.kafka.partition' => 'Job %1$s is already processing api source id: %2$s, partition id: %3$s',
   'pl.apisource.mode.poll'        => 'Poll Mode',
   'pl.apisource.mode.poll.desc'   => 'The messaging technology to use for polling, leave blank to disable Poll Mode',
   'pl.apisource.mode.push'        => 'Push Mode',

--- a/app/AvailablePlugin/ApiSource/Model/ApiSource.php
+++ b/app/AvailablePlugin/ApiSource/Model/ApiSource.php
@@ -205,7 +205,7 @@ class ApiSource extends AppModel {
       }
       
       try {
-        $messages = $this->ServerKafka->KafkaServer->consumeBatch();
+        $messages = $this->ServerKafka->KafkaServer->consumeBatch($kafkaPartitionId);
 
         if(empty($messages)) {
           // Nothing to do, so break the loop and stop the job

--- a/app/Console/Command/JobShell.php
+++ b/app/Console/Command/JobShell.php
@@ -86,7 +86,8 @@ class JobShell extends AppShell {
                                         null,
                                         _txt('rs.jb.started', array($pwent['name'], $pwent['uid'])),
                                         false,
-                                        $concurrent);
+                                        $concurrent,
+                                        $params);
         
         $this->out(_txt('rs.jb.registered', array($jobId)), 1, Shell::NORMAL);
         

--- a/app/Model/KafkaServer.php
+++ b/app/Model/KafkaServer.php
@@ -166,7 +166,7 @@ class KafkaServer extends AppModel {
     if($this->topic == null) 
       return array();
     
-    $consumed = $this->topic->consumeBatch($partitionId ?: $this->srvr['KafkaServer']['partition'],
+    $consumed = $this->topic->consumeBatch((int)$partitionId ?: $this->srvr['KafkaServer']['partition'],
                                            $this->srvr['KafkaServer']['timeout'] * 1000,
                                            $this->srvr['KafkaServer']['batch_size']);
     /*
@@ -236,7 +236,7 @@ class KafkaServer extends AppModel {
 
     $this->topic = $this->consumer->newTopic($this->srvr['KafkaServer']['topic'], $topicConf);
 
-    $this->topic->consumeStart($partitionId ?: $this->srvr['KafkaServer']['partition'], RD_KAFKA_OFFSET_STORED);
+    $this->topic->consumeStart((int)$partitionId ?: $this->srvr['KafkaServer']['partition'], RD_KAFKA_OFFSET_STORED);
 
     return true;
   }


### PR DESCRIPTION
- added int casting to partition id parameters prior to ternary comparison with the partition id value configured for the server
- modified ApiSource->poll to pass the supplied partition id to the KafkaServer->consumeBatch function
- added soft job locking based upon api source and partition id by cancelling ApiSource poll jobs if an existing job is currently running for the api source and partition

UCSD observed the best ApiSource->Poll performance results when leveraging round robin distribution, running concurrent jobs targeting each partition, and isolating topic consumption for each api source partition to one process at a time. 
