### PR TITLE
CO-2763_Invitation_Enrollment_Flow_-_Field_attribute_pointing_to_Roles-Manager_doesnt_show_field_to_input

### DIFF
--- a/app/Model/CoEnrollmentAttribute.php
+++ b/app/Model/CoEnrollmentAttribute.php
@@ -482,8 +482,11 @@ class CoEnrollmentAttribute extends AppModel {
             $attr['default'] = $efAttr['CoEnrollmentAttributeDefault'][0]['value'];
           }
           $attr['modifiable'] = $efAttr['CoEnrollmentAttributeDefault'][0]['modifiable'];
-        } elseif($efAttr['CoEnrollmentAttribute']['attribute'] == 'r:sponsor_co_person_id') {
-          // Special case for sponsor, we want to make sure the modifiable field passes
+        } elseif(in_array($efAttr['CoEnrollmentAttribute']['attribute'],
+                          array('r:sponsor_co_person_id', 'r:manager_co_person_id'),
+                          true)
+        ) {
+          // Special case for sponsor and manager, we want to make sure the modifiable field passes
           // through even if there is no default value
           if(isset($efAttr['CoEnrollmentAttributeDefault'][0]['modifiable'])) {
             $attr['modifiable'] = $efAttr['CoEnrollmentAttributeDefault'][0]['modifiable'];


### PR DESCRIPTION
Special case for sponsor and manager, we want to make sure the modifiable field passes though even if there is no default value