### PR TITLE
Provide confirmation for petition Approve or Deny (CO-2815)

### DIFF
--- a/app/Config/Schema/schema.xml
+++ b/app/Config/Schema/schema.xml
@@ -1122,6 +1122,8 @@
     <field name="approver_co_group_id" type="I">
       <constraint>REFERENCES cm_co_groups(id)</constraint>
     </field>
+    <field name="approval_confirmation_mode" type="C" size="2" />
+    <field name="approval_require_comment" type="C" size="2" />
     <!-- verify_email is no longer used (as of v2.0.0), but we can't
          drop the column since that would break changelog history -->
     <field name="verify_email" type="L" />

--- a/app/Lib/enum.php
+++ b/app/Lib/enum.php
@@ -242,6 +242,14 @@ class EmailAddressEnum {
   const Preferred     = 'preferred';
   const Recovery      = 'recovery';
 }
+  
+class EnrollmentApprovalConfirmationModeEnum
+{
+  const Always        = 'AL';
+  const Approval      = 'AP';
+  const Denial        = 'D';
+  const Never         = 'N';
+}
 
 class EnrollmentAuthzEnum {
   const AuthUser      = 'AU';

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -610,6 +610,13 @@ The request may be viewed at
     EnrollmentAuthzEnum::None           => 'None'
   ),
   
+  'en.enrollment.confmode' => array(
+    EnrollmentApprovalConfirmationModeEnum::Always   => 'Always',
+    EnrollmentApprovalConfirmationModeEnum::Approval => 'Approval Only',
+    EnrollmentApprovalConfirmationModeEnum::Denial   => 'Denial Only',
+    EnrollmentApprovalConfirmationModeEnum::Never    => 'Never',
+  ),
+  
   'en.enrollment.dupe' => array(
     EnrollmentDupeModeEnum::Duplicate       => 'Flag as Duplicate',
     EnrollmentDupeModeEnum::Merge           => 'Merge',
@@ -1498,6 +1505,10 @@ The request may be viewed at
   'fd.ef.app.base.desc' => 'Application\'s webroot location, e.g. /registry',
   'fd.ef.appr' =>     'Require Approval For Enrollment',
   'fd.ef.appr.desc' => 'If administrator approval is required, a Petition must be approved before the Enrollee becomes active.',
+  'fd.ef.appr.confmode' => 'Approval Confirmation Mode',
+  'fd.ef.appr.confmode.desc' => 'When to require JavaScript confirmation on "Approve" or "Deny" petition buttons',
+  'fd.ef.appr.reqcomment' => 'Require Comment on Approval',
+  'fd.ef.appr.reqcomment.desc' => 'When to require a comment to "Approve" or "Deny" a petition',
   'fd.ef.appr.pl' =>  'Approvers',
   'fd.ef.appr.gr' =>  'Members of this Group are authorized approvers (or else CO/COU admins by default)',
   'fd.ef.appr.ntf' =>  'Approver Notification Email Message Template',

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -617,6 +617,13 @@ The request may be viewed at
     EnrollmentApprovalConfirmationModeEnum::Never    => 'Never',
   ),
   
+  'en.enrollment.confmode.placeholder' => array(
+    EnrollmentApprovalConfirmationModeEnum::Always   => 'Required',
+    EnrollmentApprovalConfirmationModeEnum::Approval => 'Required on approval',
+    EnrollmentApprovalConfirmationModeEnum::Denial   => 'Required on denial',
+    EnrollmentApprovalConfirmationModeEnum::Never    => 'Optional',
+  ),
+  
   'en.enrollment.dupe' => array(
     EnrollmentDupeModeEnum::Duplicate       => 'Flag as Duplicate',
     EnrollmentDupeModeEnum::Merge           => 'Merge',
@@ -1504,9 +1511,13 @@ The request may be viewed at
   'fd.ef.app.base' => 'App Base location',
   'fd.ef.app.base.desc' => 'Application\'s webroot location, e.g. /registry',
   'fd.ef.appr' =>     'Require Approval For Enrollment',
+  'fd.ef.appr.approve.confirm' => 'Are you sure you want to approve this petition?',
+  'fd.ef.appr.deny.confirm' => 'Are you sure you want to deny this petition?',
   'fd.ef.appr.desc' => 'If administrator approval is required, a Petition must be approved before the Enrollee becomes active.',
   'fd.ef.appr.confmode' => 'Approval Confirmation Mode',
   'fd.ef.appr.confmode.desc' => 'When to require JavaScript confirmation on "Approve" or "Deny" petition buttons',
+  'fd.ef.appr.invalid.appr' => 'You must supply a comment when approving a petition.',
+  'fd.ef.appr.invalid.deny' => 'You must supply a comment when denying a petition.',
   'fd.ef.appr.reqcomment' => 'Require Comment on Approval',
   'fd.ef.appr.reqcomment.desc' => 'When to require a comment to "Approve" or "Deny" a petition',
   'fd.ef.appr.pl' =>  'Approvers',

--- a/app/Model/CoEnrollmentFlow.php
+++ b/app/Model/CoEnrollmentFlow.php
@@ -190,6 +190,24 @@ class CoEnrollmentFlow extends AppModel {
     'approval_required' => array(
       'rule' => array('boolean')
     ),
+    'approval_confirmation_mode' => array(
+      'rule' => array('inList',
+                      array(EnrollmentApprovalConfirmationModeEnum::Never,
+                            EnrollmentApprovalConfirmationModeEnum::Approval,
+                            EnrollmentApprovalConfirmationModeEnum::Denial,
+                            EnrollmentApprovalConfirmationModeEnum::Always)),
+      'required' => false,
+      'allowEmpty' => true
+    ),
+    'approval_require_comment' => array(
+      'rule' => array('inList',
+                      array(EnrollmentApprovalConfirmationModeEnum::Never,
+                            EnrollmentApprovalConfirmationModeEnum::Approval,
+                            EnrollmentApprovalConfirmationModeEnum::Denial,
+                            EnrollmentApprovalConfirmationModeEnum::Always)),
+      'required' => false,
+      'allowEmpty' => true
+    ),
     'approver_co_group_id' => array(
       'content' => array(
         'rule' => 'numeric',
@@ -968,6 +986,8 @@ class CoEnrollmentFlow extends AppModel {
       'name'                    => _txt('fd.ef.tmpl.lnk'),
       'co_id'                   => $coId,
       'approval_required'       => false,
+      'approval_confirmation_mode' => EnrollmentApprovalConfirmationModeEnum::Never,
+      'approval_require_comment' => EnrollmentApprovalConfirmationModeEnum::Never,
       'status'                  => TemplateableStatusEnum::Template,
       'match_policy'            => EnrollmentMatchPolicyEnum::Self,
       'authz_level'             => EnrollmentAuthzEnum::CoPerson,
@@ -1021,6 +1041,8 @@ class CoEnrollmentFlow extends AppModel {
       'name'                    => _txt('fd.ef.tmpl.arl'),
       'co_id'                   => $coId,
       'approval_required'       => false,
+      'approval_confirmation_mode' => EnrollmentApprovalConfirmationModeEnum::Never,
+      'approval_require_comment' => EnrollmentApprovalConfirmationModeEnum::Never,
       'status'                  => TemplateableStatusEnum::Template,
       'match_policy'            => EnrollmentMatchPolicyEnum::Select,
       'authz_level'             => EnrollmentAuthzEnum::CoOrCouAdmin,
@@ -1107,6 +1129,8 @@ class CoEnrollmentFlow extends AppModel {
       'name'                    => _txt('fd.ef.tmpl.csp'),
       'co_id'                   => $coId,
       'approval_required'       => true,
+      'approval_confirmation_mode' => EnrollmentApprovalConfirmationModeEnum::Never,
+      'approval_require_comment' => EnrollmentApprovalConfirmationModeEnum::Never,
       'status'                  => TemplateableStatusEnum::Template,
       'match_policy'            => EnrollmentMatchPolicyEnum::Advisory,
       'authz_level'             => EnrollmentAuthzEnum::CoOrCouAdmin,
@@ -1236,6 +1260,8 @@ class CoEnrollmentFlow extends AppModel {
       'name'                    => _txt('fd.ef.tmpl.inv'),
       'co_id'                   => $coId,
       'approval_required'       => false,
+      'approval_confirmation_mode' => EnrollmentApprovalConfirmationModeEnum::Never,
+      'approval_require_comment' => EnrollmentApprovalConfirmationModeEnum::Never,
       'status'                  => TemplateableStatusEnum::Template,
       'match_policy'            => EnrollmentMatchPolicyEnum::None,
       'authz_level'             => EnrollmentAuthzEnum::CoOrCouAdmin,
@@ -1341,6 +1367,8 @@ class CoEnrollmentFlow extends AppModel {
       'name'                    => _txt('fd.ef.tmpl.ssu'),
       'co_id'                   => $coId,
       'approval_required'       => true,
+      'approval_confirmation_mode' => EnrollmentApprovalConfirmationModeEnum::Never,
+      'approval_require_comment' => EnrollmentApprovalConfirmationModeEnum::Never,
       'status'                  => TemplateableStatusEnum::Template,
       'match_policy'            => EnrollmentMatchPolicyEnum::None,
       'authz_level'             => EnrollmentAuthzEnum::None,

--- a/app/View/CoEnrollmentFlows/fields.inc
+++ b/app/View/CoEnrollmentFlows/fields.inc
@@ -50,6 +50,8 @@
   
   $l = 1;
 ?>
+  
+<?php if($e): // we only need form interactivity for edit ?>  
 <script type="text/javascript">
   <!-- JS specific to these fields -->
   
@@ -57,7 +59,7 @@
     // Hide and show accordingly. Reset sub-popups to prevent superfluous data from
     // being saved. (ie: we don't need a group ID if approval is not required)
     
-    var approval = document.getElementById('CoEnrollmentFlowApprovalRequired').checked;
+    var approval = document.getElementById('CoEnrollmentFlowApprovalRequired')?.checked;
     
     if(approval) {
       document.getElementById('approvergroupdiv').style.display = "block";
@@ -68,7 +70,6 @@
       document.getElementById('approvergroupdiv').style.display = "none";
       document.getElementById('approvernotifydiv').style.display = "none";
       document.getElementById('approvalnotifydiv').style.display = "none";
-      document.getElementById('CoEnrollmentFlowApproverCoGroupId').value = "";
       $("#CoEnrollmentFlowRequestVetting").closest("li").hide('fade');
     }
   }
@@ -76,8 +77,8 @@
   function authn_update_gadgets() {
     // Hide and show accordingly.
 
-    var confirm = document.getElementById('CoEnrollmentFlowEmailVerificationMode').value;
-    var authn = document.getElementById('CoEnrollmentFlowRequireAuthn').checked;
+    var confirm = document.getElementById('CoEnrollmentFlowEmailVerificationMode')?.value;
+    var authn = document.getElementById('CoEnrollmentFlowRequireAuthn')?.checked;
     
     if(confirm != '<?php print VerificationModeEnum::None; ?>') {
       $("#CoEnrollmentFlowInvitationValidity").closest("ul.field-children").show('fade');
@@ -171,7 +172,7 @@
     // Hide or show gadgets according to current state
     
     // If a validation template is selected, hide the subject and body fields
-    var vtemplate = document.getElementById('CoEnrollmentFlowVerificationTemplateId').value;
+    var vtemplate = document.getElementById('CoEnrollmentFlowVerificationTemplateId')?.value;
     
     if(vtemplate) {
       $("#CoEnrollmentFlowVerificationSubject").closest("li").hide('fade');
@@ -264,6 +265,8 @@
       }
   }
 </script>
+<?php endif; ?>
+  
 <ul id="<?php print $this->action; ?>_co_enrollment_configuration" class="fields form-list form-list-admin">
   <li>
     <div class="field-name">

--- a/app/View/CoEnrollmentFlows/fields.inc
+++ b/app/View/CoEnrollmentFlows/fields.inc
@@ -526,6 +526,66 @@
       <ul class="field-children">
         <li>
           <div class="field-name">
+            <div class="field-title"><?php print _txt('fd.ef.appr.confmode'); ?></div>
+            <div class="field-desc"><?php print _txt('fd.ef.appr.confmode.desc'); ?></div>
+          </div>
+          <div class="field-info">
+            <?php
+              global $cm_lang, $cm_texts;
+              $attrs = array();
+              $attrs['value'] = (!empty($co_enrollment_flows[0]['CoEnrollmentFlow']['approval_confirmation_mode'])
+                ? $co_enrollment_flows[0]['CoEnrollmentFlow']['approval_confirmation_mode']
+                : EnrollmentApprovalConfirmationModeEnum::Never);
+              $attrs['empty'] = false;
+              
+              if($e) {
+                print $this->Form->select('approval_confirmation_mode',
+                  $cm_texts[ $cm_lang ]['en.enrollment.confmode'],
+                  $attrs);
+                
+                if($this->Form->isFieldError('approval_confirmation_mode')) {
+                  print $this->Form->error('approval_confirmation_mode');
+                }
+              } else {
+                print _txt('en.enrollment.confmode', null, $co_enrollment_flows[0]['CoEnrollmentFlow']['approval_confirmation_mode']);
+              }
+            ?>
+          </div>
+        </li>
+      </ul>
+      <ul class="field-children">
+        <li>
+          <div class="field-name">
+            <div class="field-title"><?php print _txt('fd.ef.appr.reqcomment'); ?></div>
+            <div class="field-desc"><?php print _txt('fd.ef.appr.reqcomment.desc'); ?></div>
+          </div>
+          <div class="field-info">
+            <?php
+              global $cm_lang, $cm_texts;
+              $attrs = array();
+              $attrs['value'] = (!empty($co_enrollment_flows[0]['CoEnrollmentFlow']['approval_require_comment'])
+                ? $co_enrollment_flows[0]['CoEnrollmentFlow']['approval_require_comment']
+                : EnrollmentApprovalConfirmationModeEnum::Never);
+              $attrs['empty'] = false;
+              
+              if($e) {
+                print $this->Form->select('approval_require_comment',
+                  $cm_texts[ $cm_lang ]['en.enrollment.confmode'],
+                  $attrs);
+                
+                if($this->Form->isFieldError('approval_require_comment')) {
+                  print $this->Form->error('approval_require_comment');
+                }
+              } else {
+                print _txt('en.enrollment.confmode', null, $co_enrollment_flows[0]['CoEnrollmentFlow']['approval_require_comment']);
+              }
+            ?>
+          </div>
+        </li>
+      </ul>
+      <ul class="field-children">
+        <li>
+          <div class="field-name">
             <div class="field-title"><?php print _txt('fd.ef.appr.ntf'); ?></div>
             <div class="field-desc"><?php print _txt('fd.ef.appr.ntf.desc'); ?></div>
           </div>

--- a/app/View/CoPetitions/fields.inc
+++ b/app/View/CoPetitions/fields.inc
@@ -101,6 +101,10 @@
 
   $l = 0;
   
+  // Approval confirmation mode and commenting 
+  $approvalConfirmationMode = $co_petitions[0]['CoEnrollmentFlow']['approval_confirmation_mode'] ?? EnrollmentApprovalConfirmationModeEnum::Never;
+  $approvalRequireComment = $co_petitions[0]['CoEnrollmentFlow']['approval_require_comment'] ?? EnrollmentApprovalConfirmationModeEnum::Never;
+  
   // Unlike most other views, CO Petitions dynamically generates attributes to be
   // completed according to a configuration, not according to a model. This is a
   // lot of logic to embed in a view file, and plausibly this code should be
@@ -125,6 +129,34 @@
         }
       });
     });
+    
+    function confirmPetition(action, confirmationMode, requireCommentMode, formObj) {
+      stopSpinner();
+      // First check if we need to enforce the Comment box. We only need to do this with 
+      // JavaScript if the mode is "Approval Only" or "Denial Only". If the comment field is configured 
+      // to enforce "Always", we set the field to required and let the browser handle it directly.
+      if((action == 'approve' && requireCommentMode == 'AP') || (action == 'deny' && requireCommentMode == 'D')) {
+        if($('#CoPetitionApproverComment').val().trim() == '') {
+          msg = (action == 'approve' ? '<?php print (_txt('fd.ef.appr.invalid.appr')); ?>' : '<?php print (_txt('fd.ef.appr.invalid.deny')); ?>');
+          $('#approver-comment-field-error').text(msg).show();
+          $('#CoPetitionApproverComment').focus();
+          return false; 
+        }
+      }
+      
+      // Check the confirmation mode and provide confirmations as necessary
+      if(confirmationMode == 'AL' || (confirmationMode == 'AP' && action == 'approve') || (confirmationMode == 'D' && action == 'deny')) {
+        msg = (action == 'approve' ? '<?php print (_txt('fd.ef.appr.approve.confirm')); ?>' : '<?php print (_txt('fd.ef.appr.deny.confirm')); ?>');
+        confirmed = confirm(msg);
+      } else {
+        confirmed = true;
+      }
+  
+      if(confirmed) {
+        displaySpinner();
+        formObj.submit();
+      }
+    }
   </script>
 
   <div id="<?php print $this->action; ?>_co_petitions" class="explorerContainer">
@@ -173,26 +205,42 @@
 
                       print $this->Form->create('CoPetition', $args);
 
+                      print '<div id="approve-deny-buttons">';  
+
                       if($co_petitions[0]['CoPetition']['status'] == PetitionStatusEnum::PendingApproval
                          && $permissions['approve']) {
-                        print $this->Form->submit(_txt('op.approve'),
+                        print $this->Form->button(_txt('op.approve'),
                           array(
-                            'class' => 'checkbutton approve-button',
-                            'name'  => 'action')
+                            'class' => 'approve-button btn btn-primary',
+                            'name'  => 'action',
+                            'type'  => 'button',
+                            'onclick' => "event.preventDefault(); confirmPetition('approve','" . $approvalConfirmationMode . "','" . $approvalRequireComment . "',this.form);")
                         );
                       }
-                      print $this->Form->submit(_txt('op.deny'),
+                      print $this->Form->button(_txt('op.deny'),
                         array(
-                          'class' => 'cancelbutton deny-button',
-                          'name'  => 'action')
+                          'class' => 'deny-button btn btn-primary',
+                          'name'  => 'action',
+                          'onclick' => "event.preventDefault(); confirmPetition('deny','" . $approvalConfirmationMode . "','" . $approvalRequireComment . "',this.form);")
                       );
+                      
+                      print '</div>';
 
+                      $approverCommentLabel = _txt('fd.pt.approver_comment');
+                      $requireComment = false; 
+                      if($approvalRequireComment != EnrollmentApprovalConfirmationModeEnum::Never) {
+                        $approverCommentLabel = '<span class="required">*</span> ' . _txt('fd.pt.approver_comment');
+                        if($approvalRequireComment == EnrollmentApprovalConfirmationModeEnum::Always) {
+                          $requireComment = true; // for require on approval or denial, we must enforce this with JavaScript only
+                        }
+                      }
                       print $this->Form->input('approver_comment',
                                                array(
-                                                 'label' => _txt('fd.pt.approver_comment'),
-                                                 'placeholder' => _txt('en.required', null, RequiredEnum::Optional)
+                                                 'label' => $approverCommentLabel,
+                                                 'required' => $requireComment,
+                                                 'placeholder' => _txt('en.enrollment.confmode.placeholder', null, $approvalRequireComment)
                                               ));
-
+                      print '<div id="approver-comment-field-error" class="invalid-feedback" style="display: none;"></div>';
                       print '<div class="field-desc">' . _txt('fd.pt.approver_comment.desc') . '</div>';
 
                       print $this->Form->end();

--- a/app/View/CoPetitions/fields.inc
+++ b/app/View/CoPetitions/fields.inc
@@ -130,8 +130,7 @@
       });
     });
     
-    function confirmPetition(action, confirmationMode, requireCommentMode, formObj) {
-      stopSpinner();
+    function confirmPetition(action, confirmationMode, requireCommentMode) {
       // First check if we need to enforce the Comment box. We only need to do this with 
       // JavaScript if the mode is "Approval Only" or "Denial Only". If the comment field is configured 
       // to enforce "Always", we set the field to required and let the browser handle it directly.
@@ -153,9 +152,12 @@
       }
   
       if(confirmed) {
+        $('#approve-deny-buttons input').removeClass('nospin');
         displaySpinner();
-        formObj.submit();
+        return true;
       }
+      
+      return false;
     }
   </script>
 
@@ -209,19 +211,18 @@
 
                       if($co_petitions[0]['CoPetition']['status'] == PetitionStatusEnum::PendingApproval
                          && $permissions['approve']) {
-                        print $this->Form->button(_txt('op.approve'),
+                        print $this->Form->submit(_txt('op.approve'),
                           array(
-                            'class' => 'approve-button btn btn-primary',
+                            'class' => 'approve-button btn btn-primary nospin',
                             'name'  => 'action',
-                            'type'  => 'button',
-                            'onclick' => "event.preventDefault(); confirmPetition('approve','" . $approvalConfirmationMode . "','" . $approvalRequireComment . "',this.form);")
+                            'onclick' => "return confirmPetition('approve','" . $approvalConfirmationMode . "','" . $approvalRequireComment . "');")
                         );
                       }
-                      print $this->Form->button(_txt('op.deny'),
+                      print $this->Form->submit(_txt('op.deny'),
                         array(
-                          'class' => 'deny-button btn btn-primary',
+                          'class' => 'deny-button btn btn-primary nospin',
                           'name'  => 'action',
-                          'onclick' => "event.preventDefault(); confirmPetition('deny','" . $approvalConfirmationMode . "','" . $approvalRequireComment . "',this.form);")
+                          'onclick' => "return confirmPetition('deny','" . $approvalConfirmationMode . "','" . $approvalRequireComment . "');")
                       );
                       
                       print '</div>';

--- a/app/View/CoPetitions/petition-attributes.inc
+++ b/app/View/CoPetitions/petition-attributes.inc
@@ -46,7 +46,7 @@
           'co' => $cur_co['Co']['id'],
           'mode' => PeoplePickerModeEnum::Sponsor,
           'petitionid' => $vv_co_petition_id,
-          'token' => $vv_petition_token
+          'token' => $this->action == 'view' && !isset($vv_petition_token) ? 'test' : $vv_petition_token
         );
         
         print $this->Html->url($sponsorurl);
@@ -89,7 +89,7 @@
           'co' => $cur_co['Co']['id'],
           'mode' => PeoplePickerModeEnum::Manager,
           'petitionid' => $vv_co_petition_id,
-          'token' => $vv_petition_token
+          'token' => $this->action == 'view' && !isset($vv_petition_token) ? 'test' : $vv_petition_token
         );
         
         print $this->Html->url($managerurl);

--- a/app/View/Elements/javascript.ctp
+++ b/app/View/Elements/javascript.ctp
@@ -607,7 +607,8 @@
         }
   
         // Test for invalid fields (HTML5) and turn off spinner explicitly if found.
-        if(document.querySelectorAll(":invalid").length) {
+        // Also let the .nospin class override the spin class.
+        if(document.querySelectorAll(":invalid").length || $(this).hasClass('nospin')) {
           stopSpinner();
         }
       }

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -1258,6 +1258,12 @@ body.petitionerAttributes td {
   margin: 0.5em 0;
   float: right !important;
 }
+#approve-deny-buttons {
+  display: flex;
+  gap: 0.5em;
+  margin: 0.5em 0 1em;
+  font-size: 0.9em;
+}
 body.co_petitions .approve-button,
 body.co_petitions .deny-button,
 #vetting-plugin-wrapper .approve-button,
@@ -1269,7 +1275,6 @@ body.co_petitions .deny-button,
 }
 body.co_petitions .approve-button,
 #vetting-plugin-wrapper .approve-button {
-  float: left;
   background-color: #070;
   background-image: none;
 }


### PR DESCRIPTION
This pull request implements the ability to allow confirmation for petition approval or denial (always, only on approval, only on denial, or never).

This pull request also allows petitions to be configured to require a comment (with the same possible configurations).

The default for both configurations has been set to "Never" for backward compatibility.

These features are enabled when configuring an Enrollment Flow with Approvers:
<img width="1132" alt="image" src="https://github.com/user-attachments/assets/39c5beba-2490-4ef0-b635-38a18359e689">

The following is an example in which an approver has clicked "Deny", the comment field was marked as required, but the approver did not fill it in:
<img width="856" alt="image" src="https://github.com/user-attachments/assets/f92b4de1-e57d-48b8-b365-b3e0e29c1680">

The following is an example of a confirmation box on Approval:
<img width="857" alt="image" src="https://github.com/user-attachments/assets/aa43ceae-e213-4813-82c1-7328c53c28c9">

Configuration allows for these features to be inverted as shown in the configuration screenshot, i.e. require a comment on Approve, a confirmation on Deny, etc.