### PR TITLE
Make Delete confirmation box button label consistent with link title (CO-2830)

### DIFF
--- a/app/AvailablePlugin/AnnouncementsWidget/View/CoAnnouncementChannels/index.ctp
+++ b/app/AvailablePlugin/AnnouncementsWidget/View/CoAnnouncementChannels/index.ctp
@@ -93,7 +93,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_announcement_channels',
@@ -101,9 +101,9 @@
                     $c['CoAnnouncementChannel']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoAnnouncementChannel']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/AvailablePlugin/AnnouncementsWidget/View/CoAnnouncements/index.ctp
+++ b/app/AvailablePlugin/AnnouncementsWidget/View/CoAnnouncements/index.ctp
@@ -171,7 +171,7 @@
             if($canDelete) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_announcements',
@@ -179,9 +179,9 @@
                     $c['CoAnnouncement']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoAnnouncement']['title']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/AvailablePlugin/CertificateAuthenticator/View/Certificates/index.ctp
+++ b/app/AvailablePlugin/CertificateAuthenticator/View/Certificates/index.ctp
@@ -111,7 +111,7 @@
           if($permissions['delete']) {
             print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
               . '" onclick="javascript:js_confirm_generic(\''
-              . _txt('js.remove') . '\',\''    // dialog body text
+              . _txt('js.delete') . '\',\''    // dialog body text
               . $this->Html->url(              // dialog confirm URL
                 array(
                 'plugin' => 'certificate_authenticator', // XXX can inflect from $vv_authenticator['Authenticator']['plugin']
@@ -120,9 +120,9 @@
                 $c['Certificate']['id']
                 )
               ) . '\',\''
-              . _txt('op.remove') . '\',\''    // dialog confirm button
+              . _txt('op.delete') . '\',\''    // dialog confirm button
               . _txt('op.cancel') . '\',\''    // dialog cancel button
-              . _txt('op.remove') . '\',[\''   // dialog title
+              . _txt('op.delete') . '\',[\''   // dialog title
               . filter_var(_jtxt($c['Certificate']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
               . '\']);">'
               . _txt('op.delete')

--- a/app/AvailablePlugin/DataScrubberFilter/View/DataScrubberFilterAttributes/index.ctp
+++ b/app/AvailablePlugin/DataScrubberFilter/View/DataScrubberFilterAttributes/index.ctp
@@ -118,7 +118,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'plugin' => 'data_scrubber_filter',
@@ -128,9 +128,9 @@
                     'datascrubberfilter' => $d['DataScrubberFilterAttribute']['data_scrubber_filter_id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($d['DataScrubberFilterAttribute']['attribute']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/AvailablePlugin/ElectorDataFilter/View/Elements/mvep.ctp
+++ b/app/AvailablePlugin/ElectorDataFilter/View/Elements/mvep.ctp
@@ -39,7 +39,7 @@ $action_icon = ($edit ? $this->Menu->getMenuIcon('Edit') : $this->Menu->getMenuI
           $sorted_data = Hash::sort(${$lmpl}[0][$mvep_model], "{n}.ordr", 'asc', 'numeric');
           foreach($sorted_data as $m) {
             $editable = ($action == 'edit');
-            $removetxt = _txt('js.remove');
+            $removetxt = _txt('js.delete');
             $displaystr = (!empty($mvep_field) ? $m[$mvep_field] : "");
             $laction = $action;
             // Store the action list
@@ -136,9 +136,9 @@ $action_icon = ($edit ? $this->Menu->getMenuIcon('Edit') : $this->Menu->getMenuI
                 'onclick' => array(
                   'dg_bd_txt' => $removetxt,
                   'dg_url' => $this->Html->url($dg_url),
-                  'dg_conf_btn' => _txt('op.remove'),
+                  'dg_conf_btn' => _txt('op.delete'),
                   'dg_cancel_btn' => _txt('op.cancel'),
-                  'dg_title' => _txt('op.remove'),
+                  'dg_title' => _txt('op.delete'),
                   'db_bd_txt_repl_str' => filter_var(_jtxt($displaystr),FILTER_SANITIZE_STRING),
                 ),
               );

--- a/app/AvailablePlugin/EligibilityWidget/View/Elements/mvep.ctp
+++ b/app/AvailablePlugin/EligibilityWidget/View/Elements/mvep.ctp
@@ -39,7 +39,7 @@ $action_icon = ($edit ? $this->Menu->getMenuIcon('Edit') : $this->Menu->getMenuI
           $sorted_data = Hash::sort(${$lmpl}[0][$mvep_model], "{n}.ordr", 'asc', 'numeric');
           foreach($sorted_data as $m) {
             $editable = ($action == 'edit');
-            $removetxt = _txt('js.remove');
+            $removetxt = _txt('js.delete');
             $displaystr = (!empty($mvep_field) ? $m[$mvep_field] : "");
             // Append the COU Name
             $displaystr .= ' <cite class="text-muted-cmg cm-id-display">'
@@ -143,9 +143,9 @@ $action_icon = ($edit ? $this->Menu->getMenuIcon('Edit') : $this->Menu->getMenuI
                 'onclick' => array(
                   'dg_bd_txt' => $removetxt,
                   'dg_url' => $this->Html->url($dg_url),
-                  'dg_conf_btn' => _txt('op.remove'),
+                  'dg_conf_btn' => _txt('op.delete'),
                   'dg_cancel_btn' => _txt('op.cancel'),
-                  'dg_title' => _txt('op.remove'),
+                  'dg_title' => _txt('op.delete'),
                   'db_bd_txt_repl_str' => filter_var(_jtxt($displaystr),FILTER_SANITIZE_STRING),
                 ),
               );

--- a/app/AvailablePlugin/GroupFilter/View/GroupFilterRules/index.ctp
+++ b/app/AvailablePlugin/GroupFilter/View/GroupFilterRules/index.ctp
@@ -122,7 +122,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'group_filter_rules',
@@ -131,9 +131,9 @@
                     'groupfilter' => $g['GroupFilterRule']['group_filter_id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($g['GroupFilterRule']['name_pattern']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/AvailablePlugin/IdentifierEnroller/View/IdentifierEnrollerIdentifiers/index.ctp
+++ b/app/AvailablePlugin/IdentifierEnroller/View/IdentifierEnrollerIdentifiers/index.ctp
@@ -128,7 +128,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'plugin' => 'identifier_enroller',
@@ -138,9 +138,9 @@
                     'ieid' => $e['IdentifierEnrollerIdentifier']['identifier_enroller_id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($e['IdentifierEnrollerIdentifier']['label']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/AvailablePlugin/PrivacyIdeaAuthenticator/View/TotpTokens/index.ctp
+++ b/app/AvailablePlugin/PrivacyIdeaAuthenticator/View/TotpTokens/index.ctp
@@ -96,7 +96,7 @@
           if($permissions['delete']) {
             print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
               . '" onclick="javascript:js_confirm_generic(\''
-              . _txt('js.remove') . '\',\''    // dialog body text
+              . _txt('js.delete') . '\',\''    // dialog body text
               . $this->Html->url(              // dialog confirm URL
                 array(
                 'plugin' => 'privacy_idea_authenticator', // XXX can inflect from $vv_authenticator['Authenticator']['plugin']
@@ -105,9 +105,9 @@
                 $t['TotpToken']['id']
                 )
               ) . '\',\''
-              . _txt('op.remove') . '\',\''    // dialog confirm button
+              . _txt('op.delete') . '\',\''    // dialog confirm button
               . _txt('op.cancel') . '\',\''    // dialog cancel button
-              . _txt('op.remove') . '\',[\''   // dialog title
+              . _txt('op.delete') . '\',[\''   // dialog title
               . filter_var(_jtxt($t['TotpToken']['serial']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
               . '\']);">'
               . _txt('op.delete')

--- a/app/AvailablePlugin/UnixCluster/View/UnixClusterAccounts/index.ctp
+++ b/app/AvailablePlugin/UnixCluster/View/UnixClusterAccounts/index.ctp
@@ -119,7 +119,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'plugin' => 'unix_cluster',
@@ -130,9 +130,9 @@
                     'copersonid' => $a['UnixClusterAccount']['co_person_id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($a['UnixClusterAccount']['gecos']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/AvailablePlugin/UnixCluster/View/UnixClusterGroups/index.ctp
+++ b/app/AvailablePlugin/UnixCluster/View/UnixClusterGroups/index.ctp
@@ -102,7 +102,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'plugin' => 'unix_cluster',
@@ -112,9 +112,9 @@
                     'ucid' => $g['UnixClusterGroup']['unix_cluster_id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($g['CoGroup']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/Lib/lang.php
+++ b/app/Lib/lang.php
@@ -2254,6 +2254,8 @@ The request may be viewed at
   'js.auth.lock'      =>  'Please confirm locking \x22{0}\x22 for {1}.',
   'js.auth.reset'     =>  'Please confirm resetting \x22{0}\x22 for {1}.',
   'js.auth.unlock'    =>  'Please confirm unlocking \x22{0}\x22 for {1}.',
+  'js.delete'         =>  'Are you sure you wish to delete \x22{0}\x22?  This action cannot be undone.',
+  'js.delete.role'    =>  'this role',
   'js.intrash'        =>  'Are you sure you wish to move \x22{0}\x22 to Trash? You will be able to restore it until Garbage Collector runs.',
   'js.move.trash'     =>  'Move to Trash',
   'js.ois.inventory'  =>  'Are you sure you wish to retrieve the full inventory from this backend? This may be slow and result in a large page load.',

--- a/app/View/Addresses/index.ctp
+++ b/app/View/Addresses/index.ctp
@@ -91,7 +91,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                     array(
                       'controller' => 'addresses',
@@ -99,9 +99,9 @@
                       $a['Address']['id']
                     )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($a['Address']['street']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/ApiUsers/index.ctp
+++ b/app/View/ApiUsers/index.ctp
@@ -100,7 +100,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                     array(
                       'controller' => 'api_users',
@@ -108,9 +108,9 @@
                       $a['ApiUser']['id']
                     )
                   ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($a['ApiUser']['username']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/AttributeEnumerations/index.ctp
+++ b/app/View/AttributeEnumerations/index.ctp
@@ -106,7 +106,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'attribute_enumerations',
@@ -114,7 +114,7 @@
                     $c['AttributeEnumeration']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
                 . _txt('op.remove') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['AttributeEnumeration']['optvalue']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings

--- a/app/View/Authenticators/index.ctp
+++ b/app/View/Authenticators/index.ctp
@@ -115,7 +115,7 @@
           if($permissions['delete']) {
             print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
               . '" onclick="javascript:js_confirm_generic(\''
-              . _txt('js.remove') . '\',\''    // dialog body text
+              . _txt('js.delete') . '\',\''    // dialog body text
               . $this->Html->url(              // dialog confirm URL
                 array(
                   'controller' => 'authenticators',
@@ -123,9 +123,9 @@
                   $c['Authenticator']['id']
                 )
               ) . '\',\''
-              . _txt('op.remove') . '\',\''    // dialog confirm button
+              . _txt('op.delete') . '\',\''    // dialog confirm button
               . _txt('op.cancel') . '\',\''    // dialog cancel button
-              . _txt('op.remove') . '\',[\''   // dialog title
+              . _txt('op.delete') . '\',[\''   // dialog title
               . filter_var(_jtxt($c['Authenticator']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
               . '\']);">'
               . _txt('op.delete')

--- a/app/View/Clusters/index.ctp
+++ b/app/View/Clusters/index.ctp
@@ -115,7 +115,7 @@
           if($permissions['delete']) {
             print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
               . '" onclick="javascript:js_confirm_generic(\''
-              . _txt('js.remove') . '\',\''    // dialog body text
+              . _txt('js.delete') . '\',\''    // dialog body text
               . $this->Html->url(              // dialog confirm URL
                 array(
                   'controller' => 'clusters',
@@ -123,9 +123,9 @@
                   $c['Cluster']['id']
                 )
               ) . '\',\''
-              . _txt('op.remove') . '\',\''    // dialog confirm button
+              . _txt('op.delete') . '\',\''    // dialog confirm button
               . _txt('op.cancel') . '\',\''    // dialog cancel button
-              . _txt('op.remove') . '\',[\''   // dialog title
+              . _txt('op.delete') . '\',[\''   // dialog title
               . filter_var(_jtxt($c['Cluster']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
               . '\']);">'
               . _txt('op.delete')

--- a/app/View/CoDashboardWidgets/index.ctp
+++ b/app/View/CoDashboardWidgets/index.ctp
@@ -143,7 +143,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_dashboard_widgets',
@@ -152,9 +152,9 @@
                     'codashboard' => $vv_db_id
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoDashboardWidget']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoDashboards/index.ctp
+++ b/app/View/CoDashboards/index.ctp
@@ -127,7 +127,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_dashboards',
@@ -135,9 +135,9 @@
                     $c['CoDashboard']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoDashboard']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoDepartments/index.ctp
+++ b/app/View/CoDepartments/index.ctp
@@ -104,7 +104,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_departments',
@@ -112,9 +112,9 @@
                     $c['CoDepartment']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoDepartment']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoEmailLists/index.ctp
+++ b/app/View/CoEmailLists/index.ctp
@@ -107,7 +107,7 @@
           if($d) {
             print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
               . '" onclick="javascript:js_confirm_generic(\''
-              . _txt('js.remove') . '\',\''    // dialog body text
+              . _txt('js.delete') . '\',\''    // dialog body text
               . $this->Html->url(              // dialog confirm URL
                 array(
                   'controller' => 'co_email_lists',
@@ -115,9 +115,9 @@
                   $c['CoEmailList']['id']
                 )
               ) . '\',\''
-              . _txt('op.remove') . '\',\''    // dialog confirm button
+              . _txt('op.delete') . '\',\''    // dialog confirm button
               . _txt('op.cancel') . '\',\''    // dialog cancel button
-              . _txt('op.remove') . '\',[\''   // dialog title
+              . _txt('op.delete') . '\',[\''   // dialog title
               . filter_var(_jtxt($c['CoEmailList']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
               . '\']);">'
               . _txt('op.delete')

--- a/app/View/CoEnrollmentAttributes/index.ctp
+++ b/app/View/CoEnrollmentAttributes/index.ctp
@@ -127,7 +127,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_enrollment_attributes',

--- a/app/View/CoEnrollmentFlowWedges/index.ctp
+++ b/app/View/CoEnrollmentFlowWedges/index.ctp
@@ -148,7 +148,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_enrollment_flow_wedges',

--- a/app/View/CoEnrollmentFlows/index.ctp
+++ b/app/View/CoEnrollmentFlows/index.ctp
@@ -145,7 +145,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_enrollment_flows',
@@ -153,9 +153,9 @@
                     $c['CoEnrollmentFlow']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoEnrollmentFlow']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoEnrollmentSources/index.ctp
+++ b/app/View/CoEnrollmentSources/index.ctp
@@ -126,7 +126,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_enrollment_sources',
@@ -135,7 +135,7 @@
                     'coef' => $vv_ef_id
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
                 . _txt('op.remove') . '\',[\''   // dialog title
                 . filter_var(_jtxt($vv_all_ois[ $c['CoEnrollmentSource']['org_identity_source_id'] ]),FILTER_SANITIZE_STRING)  // dialog body text replacement strings

--- a/app/View/CoExpirationPolicies/index.ctp
+++ b/app/View/CoExpirationPolicies/index.ctp
@@ -103,7 +103,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_expiration_policies',
@@ -111,7 +111,7 @@
                     $c['CoExpirationPolicy']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
                 . _txt('op.remove') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoExpirationPolicy']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings

--- a/app/View/CoExtendedAttributes/index.ctp
+++ b/app/View/CoExtendedAttributes/index.ctp
@@ -97,7 +97,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_extended_attributes',
@@ -106,7 +106,7 @@
                     'co' => $cur_co['Co']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
                 . _txt('op.remove') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoExtendedAttribute']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings

--- a/app/View/CoExtendedTypes/index.ctp
+++ b/app/View/CoExtendedTypes/index.ctp
@@ -144,7 +144,7 @@
                 // We include attr in the request so we know where to redirect to when we're done
                 print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                   . '" onclick="javascript:js_confirm_generic(\''
-                  . _txt('js.remove') . '\',\''    // dialog body text
+                  . _txt('js.delete') . '\',\''    // dialog body text
                   . $this->Html->url(              // dialog confirm URL
                     array(
                       'controller' => 'co_extended_types',
@@ -153,9 +153,9 @@
                       '?' => array('attr' => $attr)
                     )
                   ) . '\',\''
-                  . _txt('op.remove') . '\',\''    // dialog confirm button
+                  . _txt('op.delete') . '\',\''    // dialog confirm button
                   . _txt('op.cancel') . '\',\''    // dialog cancel button
-                  . _txt('op.remove') . '\',[\''   // dialog title
+                  . _txt('op.delete') . '\',[\''   // dialog title
                   . filter_var(_jtxt($c['CoExtendedType']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                   . '\']);">'
                   . _txt('op.delete')

--- a/app/View/CoGroupOisMappings/index.ctp
+++ b/app/View/CoGroupOisMappings/index.ctp
@@ -118,7 +118,7 @@
           if($permissions['delete']) {
             print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
               . '" onclick="javascript:js_confirm_generic(\''
-              . _txt('js.remove') . '\',\''    // dialog body text
+              . _txt('js.delete') . '\',\''    // dialog body text
               . $this->Html->url(              // dialog confirm URL
                 array(
                   'controller' => 'co_group_ois_mappings',
@@ -126,9 +126,9 @@
                   $c['CoGroupOisMapping']['id']
                 )
               ) . '\',\''
-              . _txt('op.remove') . '\',\''    // dialog confirm button
+              . _txt('op.delete') . '\',\''    // dialog confirm button
               . _txt('op.cancel') . '\',\''    // dialog cancel button
-              . _txt('op.remove') . '\',[\''   // dialog title
+              . _txt('op.delete') . '\',[\''   // dialog title
               . filter_var(_jtxt($c['CoGroupOisMapping']['pattern']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
               . '\']);">'
               . _txt('op.delete')

--- a/app/View/CoGroups/fields.inc
+++ b/app/View/CoGroups/fields.inc
@@ -306,7 +306,7 @@
                 if($permissions['delete']) {
                   print '<a class="deletebutton" title="' . _txt('op.delete')
                     . '" onclick="javascript:js_confirm_generic(\''
-                    . _txt('js.remove') . '\',\''    // dialog body text
+                    . _txt('js.delete') . '\',\''    // dialog body text
                     . $this->Html->url(              // dialog confirm URL
                       array(
                         'controller' => 'identifiers',
@@ -315,9 +315,9 @@
                         'return' => 'group'
                       )
                     ) . '\',\''
-                    . _txt('op.remove') . '\',\''    // dialog confirm button
+                    . _txt('op.delete') . '\',\''    // dialog confirm button
                     . _txt('op.cancel') . '\',\''    // dialog cancel button
-                    . _txt('op.remove') . '\',[\''   // dialog title
+                    . _txt('op.delete') . '\',[\''   // dialog title
                     . filter_var(_jtxt($id['identifier']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                     . '\']);">'
                     . _txt('op.delete')

--- a/app/View/CoGroups/index.ctp
+++ b/app/View/CoGroups/index.ctp
@@ -513,7 +513,7 @@
                 if($d) {
                   print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                     . '" onclick="javascript:js_confirm_generic(\''
-                    . _txt('js.remove') . '\',\''    // dialog body text
+                    . _txt('js.delete') . '\',\''    // dialog body text
                     . $this->Html->url(              // dialog confirm URL
                       array(
                         'controller' => 'co_groups',
@@ -522,9 +522,9 @@
                         'co' => $this->params['named']['co']
                       )
                     ) . '\',\''
-                    . _txt('op.remove') . '\',\''    // dialog confirm button
+                    . _txt('op.delete') . '\',\''    // dialog confirm button
                     . _txt('op.cancel') . '\',\''    // dialog cancel button
-                    . _txt('op.remove') . '\',[\''   // dialog title
+                    . _txt('op.delete') . '\',[\''   // dialog title
                     . filter_var(_jtxt($c['CoGroup']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                     . '\']);">'
                     . _txt('op.delete')

--- a/app/View/CoIdentifierAssignments/index.ctp
+++ b/app/View/CoIdentifierAssignments/index.ctp
@@ -153,7 +153,7 @@
           if($permissions['delete']) {
             print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
               . '" onclick="javascript:js_confirm_generic(\''
-              . _txt('js.remove') . '\',\''    // dialog body text
+              . _txt('js.delete') . '\',\''    // dialog body text
               . $this->Html->url(              // dialog confirm URL
                 array(
                   'controller' => 'co_identifier_assignments',

--- a/app/View/CoIdentifierValidators/index.ctp
+++ b/app/View/CoIdentifierValidators/index.ctp
@@ -135,7 +135,7 @@
               if($permissions['delete']) {
                 print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                   . '" onclick="javascript:js_confirm_generic(\''
-                  . _txt('js.remove') . '\',\''    // dialog body text
+                  . _txt('js.delete') . '\',\''    // dialog body text
                   . $this->Html->url(              // dialog confirm URL
                     array(
                       'controller' => 'co_identifier_validators',

--- a/app/View/CoLocalizations/index.ctp
+++ b/app/View/CoLocalizations/index.ctp
@@ -91,7 +91,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_localizations',
@@ -100,9 +100,9 @@
                     'co' => $cur_co['Co']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoLocalization']['lkey']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoMessageTemplates/index.ctp
+++ b/app/View/CoMessageTemplates/index.ctp
@@ -111,7 +111,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_message_templates',
@@ -119,7 +119,7 @@
                     $c['CoMessageTemplate']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
                 . _txt('op.remove') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoMessageTemplate']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings

--- a/app/View/CoNavigationLinks/index.ctp
+++ b/app/View/CoNavigationLinks/index.ctp
@@ -102,7 +102,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_navigation_links',
@@ -111,9 +111,9 @@
                     'co' => $cur_co['Co']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoNavigationLink']['title']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoNsfDemographics/index.ctp
+++ b/app/View/CoNsfDemographics/index.ctp
@@ -116,9 +116,9 @@
                 . '" onclick="javascript:js_confirm_generic(\''
                 . _txt('op.delete.consfdemographics') . '\',\'' // dialog body text
                 . $this->Html->url($args) . '\',\''             // dialog confirm URL
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\');">'   // dialog title
+                . _txt('op.delete') . '\');">'   // dialog title
                 . _txt('op.delete')
                 . '</button>';
             }

--- a/app/View/CoPeople/fields.inc
+++ b/app/View/CoPeople/fields.inc
@@ -304,7 +304,7 @@
           'icon'    => 'circle-close',
           'title'   => _txt('op.delete'),
           'url'     => 'javascript:js_confirm_generic(\''
-            . _txt('js.remove') . '\',\''    // dialog body text
+            . _txt('js.delete') . '\',\''    // dialog body text
             . $this->Html->url(              // dialog confirm URL
               array(
                 'controller' => 'co_people',
@@ -312,9 +312,9 @@
                 $co_people[0]['CoPerson']['id']
               )
             ) . '\',\''
-            . _txt('op.remove') . '\',\''    // dialog confirm button
+            . _txt('op.delete') . '\',\''    // dialog confirm button
             . _txt('op.cancel') . '\',\''    // dialog cancel button
-            . _txt('op.remove') . '\',[\''   // dialog title
+            . _txt('op.delete') . '\',[\''   // dialog title
             . filter_var(_jtxt(generateCn($co_people[0]['PrimaryName'])),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
             . '\'])'
         );
@@ -569,11 +569,11 @@
                             'url' => 'javascript:void(0);',
                             'label' => _txt('op.delete'),
                             'onclick' => array(
-                              'dg_bd_txt' => _txt('js.remove'),
+                              'dg_bd_txt' => _txt('js.delete'),
                               'dg_url' => $this->Html->url($dg_url),
-                              'dg_conf_btn' => _txt('op.remove'),
+                              'dg_conf_btn' => _txt('op.delete'),
                               'dg_cancel_btn' => _txt('op.cancel'),
-                              'dg_title' => _txt('op.remove'),
+                              'dg_title' => _txt('op.delete'),
                               'db_bd_txt_repl_str' => filter_var(_jtxt(generateCn($n)), FILTER_SANITIZE_STRING),
                             ),
                           );
@@ -779,7 +779,7 @@
                       'order' => $this->Menu->getMenuOrder('Delete'),
                       'icon' => $this->Menu->getMenuIcon('Delete'),
                       'url' => 'javascript:void(0);',
-                      'label' => _txt('op.delete'),
+                      'label' => _txt('op.remove'),
                       'onclick' => array(
                         'dg_bd_txt' => _txt('js.remove.member'),
                         'dg_url' => $this->Html->url($dg_url),
@@ -1107,9 +1107,9 @@
                     '#collapse_link_' . md5("CoPersonRole" . $r['id']),
                     $linkparams
                   );
-
-                  // Badge Column
                   print '</div>';
+                  
+                  // Badge Column
                   print '<div class="field-data data-label">';
                   print $this->element('badgeList', array('vv_badge_list' => $badge_list_role));
                   print '</div>';
@@ -1201,12 +1201,12 @@
                         'icon' => $this->Menu->getMenuIcon('Delete'),
                         'label' => _txt('op.delete'),
                         'onclick' => array(
-                          'dg_bd_txt' => _txt('js.remove'),
+                          'dg_bd_txt' => _txt('js.delete'),
                           'dg_url' => $this->Html->url($dr_url),
-                          'dg_conf_btn' => _txt('op.remove'),
+                          'dg_conf_btn' => _txt('op.delete'),
                           'dg_cancel_btn' => _txt('op.cancel'),
-                          'dg_title' => _txt('op.remove'),
-                          'db_bd_txt_repl_str' => filter_var(_jtxt(generateCn($co_people[0]['PrimaryName'])), FILTER_SANITIZE_STRING),
+                          'dg_title' => _txt('op.delete'),
+                          'db_bd_txt_repl_str' => filter_var(_jtxt(!empty($r['title']) ? $r['title'] : _txt('js.delete.role')), FILTER_SANITIZE_STRING),
                         ),
                       );
                     }

--- a/app/View/CoPersonRoles/index.ctp
+++ b/app/View/CoPersonRoles/index.ctp
@@ -115,7 +115,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                     array(
                       'controller' => 'co_person_roles',
@@ -124,9 +124,9 @@
                       'co' => $cur_co['Co']['id']
                     )
                   ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt(generateCn($p['PrimaryName'])),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete') . '</button>' . "\n";

--- a/app/View/CoPetitions/index.ctp
+++ b/app/View/CoPetitions/index.ctp
@@ -204,7 +204,7 @@
                    && $p["permissions"]["deny"])) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete-a',array($displayNameWithId))
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_petitions',
@@ -212,9 +212,9 @@
                     $p['CoPetition']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($displayNameWithId),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoPipelines/index.ctp
+++ b/app/View/CoPipelines/index.ctp
@@ -89,7 +89,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_pipelines',
@@ -97,9 +97,9 @@
                     $c['CoPipeline']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoPipeline']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoProvisioningTargetFilters/index.ctp
+++ b/app/View/CoProvisioningTargetFilters/index.ctp
@@ -122,7 +122,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_provisioning_target_filters',

--- a/app/View/CoProvisioningTargets/index.ctp
+++ b/app/View/CoProvisioningTargets/index.ctp
@@ -174,7 +174,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_provisioning_targets',

--- a/app/View/CoSelfServicePermissions/index.ctp
+++ b/app/View/CoSelfServicePermissions/index.ctp
@@ -109,7 +109,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_self_service_permissions',

--- a/app/View/CoServices/index.ctp
+++ b/app/View/CoServices/index.ctp
@@ -111,7 +111,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_services',
@@ -119,9 +119,9 @@
                     $c['CoService']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoService']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/CoTermsAndConditions/index.ctp
+++ b/app/View/CoTermsAndConditions/index.ctp
@@ -118,7 +118,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_terms_and_conditions',
@@ -127,7 +127,7 @@
                     'co' => $cur_co['Co']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
                 . _txt('op.remove') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoTermsAndConditions']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings

--- a/app/View/CoThemes/index.ctp
+++ b/app/View/CoThemes/index.ctp
@@ -85,7 +85,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'co_themes',
@@ -93,9 +93,9 @@
                     $c['CoTheme']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['CoTheme']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/ConfigurationLabels/index.ctp
+++ b/app/View/ConfigurationLabels/index.ctp
@@ -96,7 +96,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                     array(
                       'controller' => 'configuration_labels',

--- a/app/View/Cous/index.ctp
+++ b/app/View/Cous/index.ctp
@@ -114,7 +114,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'cous',
@@ -122,9 +122,9 @@
                     $c['Cou']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['Cou']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/DataFilters/index.ctp
+++ b/app/View/DataFilters/index.ctp
@@ -119,7 +119,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'data_filters',
@@ -127,9 +127,9 @@
                     $d['DataFilter']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($d['DataFilter']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/Dictionaries/index.ctp
+++ b/app/View/Dictionaries/index.ctp
@@ -105,7 +105,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'dictionaries',
@@ -113,9 +113,9 @@
                     $c['Dictionary']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['Dictionary']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/DictionaryEntries/index.ctp
+++ b/app/View/DictionaryEntries/index.ctp
@@ -146,7 +146,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'dictionary_entries',
@@ -154,9 +154,9 @@
                     $c['DictionaryEntry']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['DictionaryEntry']['value']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/Elements/mvpa.ctp
+++ b/app/View/Elements/mvpa.ctp
@@ -88,7 +88,7 @@
         if(!empty(${$lmpl}[0][$mvpa_model])) {
           foreach(${$lmpl}[0][$mvpa_model] as $m) {
             $editable = ($action == 'edit');
-            $removetxt = _txt('js.remove');
+            $removetxt = _txt('js.delete');
             $displaystr = (!empty($mvpa_field) ? $m[$mvpa_field] : "");
             $laction = $action;
             // Store the action list
@@ -312,9 +312,9 @@
                 'onclick' => array(
                   'dg_bd_txt' => $removetxt,
                   'dg_url' => $this->Html->url($dg_url),
-                  'dg_conf_btn' => _txt('op.remove'),
+                  'dg_conf_btn' => _txt('op.delete'),
                   'dg_cancel_btn' => _txt('op.cancel'),
-                  'dg_title' => _txt('op.remove'),
+                  'dg_title' => _txt('op.delete'),
                   'db_bd_txt_repl_str' => filter_var(_jtxt($displaystr),FILTER_SANITIZE_STRING),
                 ),
               );

--- a/app/View/EmailAddresses/index.ctp
+++ b/app/View/EmailAddresses/index.ctp
@@ -89,7 +89,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'email_addresses',
@@ -97,9 +97,9 @@
                     $e['EmailAddress']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($e['EmailAddress']['mail']),FILTER_SANITIZE_EMAIL)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/Identifiers/index.ctp
+++ b/app/View/Identifiers/index.ctp
@@ -106,7 +106,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'identifiers',
@@ -114,9 +114,9 @@
                     $a['Identifier']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($a['Identifier']['identifier']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/IdentityDocuments/index.ctp
+++ b/app/View/IdentityDocuments/index.ctp
@@ -119,7 +119,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'identity_documents',
@@ -127,9 +127,9 @@
                     $d['IdentityDocument']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . _txt('en.id.type', null, $d['IdentityDocument']['document_type'])  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/MatchServerAttributes/index.ctp
+++ b/app/View/MatchServerAttributes/index.ctp
@@ -105,7 +105,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'match_server_attributes',

--- a/app/View/NavigationLinks/index.ctp
+++ b/app/View/NavigationLinks/index.ctp
@@ -100,7 +100,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'navigation_links',
@@ -108,9 +108,9 @@
                     $c['NavigationLink']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['NavigationLink']['title']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/OrgIdentities/fields.inc
+++ b/app/View/OrgIdentities/fields.inc
@@ -313,11 +313,11 @@
                             'url' => 'javascript:void(0);',
                             'label' => _txt('op.delete'),
                             'onclick' => array(
-                              'dg_bd_txt' => _txt('js.remove'),
+                              'dg_bd_txt' => _txt('js.delete'),
                               'dg_url' => $this->Html->url($dg_url),
-                              'dg_conf_btn' => _txt('op.remove'),
+                              'dg_conf_btn' => _txt('op.delete'),
                               'dg_cancel_btn' => _txt('op.cancel'),
-                              'dg_title' => _txt('op.remove'),
+                              'dg_title' => _txt('op.delete'),
                               'db_bd_txt_repl_str' => filter_var(_jtxt(generateCn($n)), FILTER_SANITIZE_STRING),
                             ),
                           );

--- a/app/View/OrgIdentities/index.ctp
+++ b/app/View/OrgIdentities/index.ctp
@@ -169,7 +169,7 @@ if(!empty($vv_alphabet_search)) {
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'org_identities',
@@ -177,9 +177,9 @@ if(!empty($vv_alphabet_search)) {
                     $p['OrgIdentity']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt(generateCn($p['PrimaryName'])),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/OrgIdentitySourceFilters/index.ctp
+++ b/app/View/OrgIdentitySourceFilters/index.ctp
@@ -122,7 +122,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'org_identity_source_filters',

--- a/app/View/OrgIdentitySources/index.ctp
+++ b/app/View/OrgIdentitySources/index.ctp
@@ -171,7 +171,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'org_identity_sources',
@@ -179,7 +179,7 @@
                     $o['OrgIdentitySource']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
                 . _txt('op.remove') . '\',[\''   // dialog title
                 . filter_var(_jtxt($o['OrgIdentitySource']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings

--- a/app/View/OrganizationSources/index.ctp
+++ b/app/View/OrganizationSources/index.ctp
@@ -131,7 +131,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'organization_sources',

--- a/app/View/Organizations/index.ctp
+++ b/app/View/Organizations/index.ctp
@@ -117,7 +117,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'organizations',
@@ -125,9 +125,9 @@
                     $c['Organization']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['Organization']['name']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/Servers/index.ctp
+++ b/app/View/Servers/index.ctp
@@ -107,7 +107,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'servers',
@@ -115,9 +115,9 @@
                     $c['Server']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['Server']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/TelephoneNumbers/index.ctp
+++ b/app/View/TelephoneNumbers/index.ctp
@@ -89,7 +89,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'telephone_numbers',
@@ -97,9 +97,9 @@
                     $t['TelephoneNumber']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($t['TelephoneNumber']['number']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/Urls/index.ctp
+++ b/app/View/Urls/index.ctp
@@ -89,7 +89,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'urls',
@@ -97,9 +97,9 @@
                     $u['Url']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($u['Url']['url']),FILTER_SANITIZE_URL)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')

--- a/app/View/VettingRequests/fields.inc
+++ b/app/View/VettingRequests/fields.inc
@@ -127,9 +127,9 @@
                   $vetting_requests[0]['VettingRequest']['id']
                 )
               ) . '\',\''
-              . _txt('op.remove') . '\',\''    // dialog confirm button
+              . _txt('op.delete') . '\',\''    // dialog confirm button
               . _txt('op.cancel') . '\',\''    // dialog cancel button
-              . _txt('op.remove') . '\',[\''   // dialog title
+              . _txt('op.delete') . '\',[\''   // dialog title
               . filter_var(_jtxt($vetting_requests[0]['VettingRequest']['id']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
               . '\']);">'
               . _txt('op.cancel')

--- a/app/View/VettingRequests/index.ctp
+++ b/app/View/VettingRequests/index.ctp
@@ -150,9 +150,9 @@
                       $c['VettingRequest']['id']
                     )
                   ) . '\',\''
-                  . _txt('op.remove') . '\',\''    // dialog confirm button
+                  . _txt('op.delete') . '\',\''    // dialog confirm button
                   . _txt('op.cancel') . '\',\''    // dialog cancel button
-                  . _txt('op.remove') . '\',[\''   // dialog title
+                  . _txt('op.delete') . '\',[\''   // dialog title
                   . filter_var(_jtxt($c['VettingRequest']['id']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                   . '\']);">'
                   . _txt('op.cancel')

--- a/app/View/VettingSteps/index.ctp
+++ b/app/View/VettingSteps/index.ctp
@@ -133,7 +133,7 @@
             if($permissions['delete']) {
               print '<button type="button" class="deletebutton" title="' . _txt('op.delete')
                 . '" onclick="javascript:js_confirm_generic(\''
-                . _txt('js.remove') . '\',\''    // dialog body text
+                . _txt('js.delete') . '\',\''    // dialog body text
                 . $this->Html->url(              // dialog confirm URL
                   array(
                     'controller' => 'vetting_steps',
@@ -141,9 +141,9 @@
                     $c['VettingStep']['id']
                   )
                 ) . '\',\''
-                . _txt('op.remove') . '\',\''    // dialog confirm button
+                . _txt('op.delete') . '\',\''    // dialog confirm button
                 . _txt('op.cancel') . '\',\''    // dialog cancel button
-                . _txt('op.remove') . '\',[\''   // dialog title
+                . _txt('op.delete') . '\',[\''   // dialog title
                 . filter_var(_jtxt($c['VettingStep']['description']),FILTER_SANITIZE_STRING)  // dialog body text replacement strings
                 . '\']);">'
                 . _txt('op.delete')


### PR DESCRIPTION
This is a trivial change that touches many files. The point of this is to ensure that when a user clicks "Delete" as an action - the confirmation dialog box title, description, and confirmation button also reads "Delete". This also fixes the confirmation box language when deleting a role from the Person Canvas so that the description names the Role title or a generic reference if there is no title (rather than displaying the person name, which is confusing).