### PR TITLE
Fix top-bar flex layout on redirect page (NOJIRA)

### DIFF
--- a/app/View/Layouts/redirect.ctp
+++ b/app/View/Layouts/redirect.ctp
@@ -125,7 +125,7 @@
     <!-- Primary layout -->
     <div id="comanage-wrapper">
 
-      <div id="top-menu">
+      <div id="top-menu" <?php if(empty($vv_NavLinks) && empty($vv_CoNavLinks)) print 'class="top-menu-redirect"'; ?>>
         <?php if(!empty($vv_NavLinks) || !empty($vv_CoNavLinks)): ?>
           <div id="user-defined-links-top">
             <?php print $this->element('links'); // XXX allow user to set this location (e.g. top or side) ?>

--- a/app/webroot/css/co-base.css
+++ b/app/webroot/css/co-base.css
@@ -124,6 +124,9 @@ a {
   z-index: 20;
   min-height: 37px;
 }
+#top-menu.top-menu-redirect {
+  justify-content: flex-end;
+}
 #top-menu-left {
   display: flex;
   align-items: center;


### PR DESCRIPTION
This PR fixes a trivial problem with flex justification within the top bar during redirect to account for if the CO settings contain navigation links or not. 